### PR TITLE
Fixed Load_A not correctly reported issue

### DIFF
--- a/src/data_objects.cpp
+++ b/src/data_objects.cpp
@@ -131,7 +131,7 @@ const data_object_t data_objects[] = {
     {0x70, TS_OUTPUT, TS_READ_ALL, TS_T_FLOAT32, 2, (void*) &(ls_bus.voltage),                  "Bat_V"},
     {0x71, TS_OUTPUT, TS_READ_ALL, TS_T_FLOAT32, 2, (void*) &(hs_bus.voltage),                  "Solar_V"},
     {0x72, TS_OUTPUT, TS_READ_ALL, TS_T_FLOAT32, 2, (void*) &(ls_bus.current),                  "Bat_A"},
-    {0x73, TS_OUTPUT, TS_READ_ALL, TS_T_FLOAT32, 2, (void*) &(load.bus->current),               "Load_A"},
+    {0x73, TS_OUTPUT, TS_READ_ALL, TS_T_FLOAT32, 2, (void*) &(load_bus.current),                "Load_A"},
     {0x74, TS_OUTPUT, TS_READ_ALL, TS_T_FLOAT32, 1, (void*) &(charger.bat_temperature),         "Bat_degC"},
     {0x75, TS_OUTPUT, TS_READ_ALL, TS_T_BOOL,    1, (void*) &(charger.ext_temp_sensor),         "BatTempExt"},
     {0x76, TS_OUTPUT, TS_READ_ALL, TS_T_FLOAT32, 1, (void*) &(mcu_temp),                        "MCU_degC"},


### PR DESCRIPTION
At compile time &(load.bus->current) will resolve to a different
(wrong) address than after assignment of "load_bus" to load.bus at runtime.