### PR TITLE
Working CAN

### DIFF
--- a/src/can_msg_queue.cpp
+++ b/src/can_msg_queue.cpp
@@ -1,3 +1,5 @@
+#ifndef UNIT_TEST
+
 #include "mbed.h"
 #ifdef STM32F0  // STM32L0 does not have CAN
 
@@ -49,3 +51,4 @@ int CANMsgQueue::first(CANMessage& msg) {
 }
 
 #endif /* STM32F0 */
+#endif

--- a/src/can_msg_queue.cpp
+++ b/src/can_msg_queue.cpp
@@ -1,4 +1,4 @@
-
+#include "mbed.h"
 #ifdef STM32F0  // STM32L0 does not have CAN
 
 #include "can_msg_queue.h"

--- a/src/config.h_template
+++ b/src/config.h_template
@@ -27,7 +27,7 @@
 //#define DCDC_MODE_INIT      MODE_NANOGRID
 
 // basic battery configuration
-#define BATTERY_TYPE        BAT_TYPE_GEL    ///< GEL most suitable for general batteries (see battery.h for other types)
+#define BATTERY_TYPE        BAT_TYPE_GEL    ///< GEL most suitable for general batteries (see bat_charger.h for other types)
 #define BATTERY_NUM_CELLS   6               ///< For lead-acid batteries: 6 for 12V system, 12 for 24V system
 #define BATTERY_CAPACITY    40              ///< Cell capacity or sum of parallel cells capacity (Ah)
 

--- a/src/data_objects.cpp
+++ b/src/data_objects.cpp
@@ -225,14 +225,29 @@ const uint16_t pub_emoncms_ids[] = {
     0x06, 0xA5, 0xA6      // SOC, SOH, DayCount
 };
 
-ts_pub_channel_t pub_channels[] = {
-    { "Serial_1s", pub_serial_ids, sizeof(pub_serial_ids)/sizeof(uint16_t), false },
-    { "EmonCMS_10s", pub_emoncms_ids, sizeof(pub_emoncms_ids)/sizeof(uint16_t), false }
+// stores object-ids of values to be published via CAN
+const uint16_t pub_can[] = {
+    0x01, // internal time stamp
+    0x70, 0x71, 0x72, 0x73, 0x7A,  // voltage + current
+    0x74, 0x76, 0x77,           // temperatures
+    0x04, 0x78, 0x79,           // LoadState, ChgState, DCDCState
+    0xA0, 0xA1, 0xA2, 0xA3,     // daily energy throughput
+    0x0F, 0x10,     // SolarMaxDay_W, LoadMaxDay_W
+    0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7, 0xB8, 0xB9,     // V, I, T max
+    0x06, 0xA4  // SOC, coulomb counter
+};
+
+
+const ts_pub_channel_t pub_channels[] = {
+    { "Serial_1s",      pub_serial,     sizeof(pub_serial)/sizeof(uint16_t) },
+    { "EmonCMS_10s",    pub_emoncms,    sizeof(pub_emoncms)/sizeof(uint16_t) },
+    { "CAN_1s",         pub_can,        sizeof(pub_can)/sizeof(uint16_t) },
 };
 
 // TODO: find better solution than manual configuration of channel number
 volatile const int pub_channel_serial = 0;
 volatile const int pub_channel_emoncms = 1;
+volatile const int PUB_CHANNEL_CAN = 2;
 
 ThingSet ts(
     data_objects, sizeof(data_objects)/sizeof(data_object_t),

--- a/src/data_objects.cpp
+++ b/src/data_objects.cpp
@@ -226,22 +226,23 @@ const uint16_t pub_emoncms_ids[] = {
 };
 
 // stores object-ids of values to be published via CAN
-const uint16_t pub_can[] = {
-    0x01, // internal time stamp
-    0x70, 0x71, 0x72, 0x73, 0x7A,  // voltage + current
+const uint16_t pub_can_ids[] = {
+    // 0x01, // internal time stamp
+    0x73, 0x72, 0x71, 0x70, 0x7A,  // voltage + current
     0x74, 0x76, 0x77,           // temperatures
     0x04, 0x78, 0x79,           // LoadState, ChgState, DCDCState
     0xA0, 0xA1, 0xA2, 0xA3,     // daily energy throughput
     0x0F, 0x10,     // SolarMaxDay_W, LoadMaxDay_W
     0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7, 0xB8, 0xB9,     // V, I, T max
-    0x06, 0xA4  // SOC, coulomb counter
+    0x06, 0xA4,  // SOC, coulomb counter
+    0x7D, 0x7E, 0x7F,
 };
 
 
-const ts_pub_channel_t pub_channels[] = {
-    { "Serial_1s",      pub_serial,     sizeof(pub_serial)/sizeof(uint16_t) },
-    { "EmonCMS_10s",    pub_emoncms,    sizeof(pub_emoncms)/sizeof(uint16_t) },
-    { "CAN_1s",         pub_can,        sizeof(pub_can)/sizeof(uint16_t) },
+ts_pub_channel_t pub_channels[] = {
+    { "Serial_1s",      pub_serial_ids,     sizeof(pub_serial_ids)/sizeof(uint16_t) },
+    { "EmonCMS_10s",    pub_emoncms_ids,    sizeof(pub_emoncms_ids)/sizeof(uint16_t) },
+    { "CAN_1s",         pub_can_ids,        sizeof(pub_can_ids)/sizeof(uint16_t) },
 };
 
 // TODO: find better solution than manual configuration of channel number

--- a/src/interface_can.cpp
+++ b/src/interface_can.cpp
@@ -19,28 +19,35 @@
 #include "config.h"
 
 #ifdef CAN_ENABLED
+#include "pcb.h"
+
+#ifndef HAS_CAN
+#error The hardware does not support CAN, please undefine CAN_ENABLED
+#endif
 
 #include "mbed.h"
-#include "config.h"
 #include "can_msg_queue.h"
 //#include "can_iso_tp.h"
 
-#include "data_objects.h"
-#include "half_bridge.h"
 #include "thingset.h"
+#include "thingset_can.h"
 
 extern Serial serial;
 extern CAN can;
 
+#ifndef CAN_SPEED
+#define CAN_SPEED 250000    // 250 kHz
+#endif
+#ifndef CAN_NODE_ID
+#define CAN_NODE_ID 10
+#endif
+
+CAN can(PIN_CAN_RX, PIN_CAN_TX, CAN_SPEED);
+DigitalOut can_disable(PIN_CAN_STB);
+
 CANMsgQueue can_tx_queue;
 CANMsgQueue can_rx_queue;
 
-#define CAN_TS_T_TRUE 61
-#define CAN_TS_T_FALSE 60
-#define CAN_TS_T_POS_INT32  6
-#define CAN_TS_T_NEG_INT32  7
-#define CAN_TS_T_FLOAT32 30
-#define CAN_TS_T_DECFRAC 36
 //----------------------------------------------------------------------------
 // preliminary simple CAN functions to send data to the bus for logging
 // Data format based on CBOR specification (except for first byte, which uses
@@ -49,129 +56,82 @@ CANMsgQueue can_rx_queue;
 // Protocol details:
 // https://github.com/LibreSolar/ThingSet/blob/master/can.md
 
-static uint8_t can_node_id = 42;
+static uint8_t can_node_id = CAN_NODE_ID;
 
-void can_pub_msg(const data_object_t& data_obj)
+extern ThingSet ts;
+ThingSetCAN ts_can;
+
+
+void ThingSetCAN::init_hw()
 {
-    union float2bytes { float f; char b[4]; } f2b;     // for conversion of float to single bytes
+    can_disable = 0;
+    can.mode(CAN::Normal);
+    //can.attach(&can_receive);
 
-    int msg_priority = 6;
+    // TXFP: Transmit FIFO priority driven by request order (chronologically)
+    // NART: No automatic retransmission
+    CAN1->MCR |= CAN_MCR_TXFP | CAN_MCR_NART;
 
+}
+
+void ThingSetCAN::process_1s()
+{
+    ts_can.pub();
+    ts_can.process_asap();
+}
+
+bool ThingSetCAN::pub_object(const data_object_t& data_obj)
+{
     CANMessage msg;
     msg.format = CANExtended;
     msg.type = CANData;
 
-    msg.id = msg_priority << 26
-        | (1U << 24) | (1U << 25)   // identify as publication message
-        | data_obj.id << 8
-        | can_node_id;
+    int encode_len = ts.encode_msg_can(data_obj, can_node_id, msg.id, msg.data);
 
-    // first byte: TinyTP-header or data type for single frame message
-    // currently: no multi-frame and no timestamp
-    msg.data[0] = 0x00;
-
-    int32_t value;
-    uint32_t value_abs;
-
-    // CBOR byte order: most significant byte first
-    switch (data_obj.type) {
-        case TS_T_FLOAT32:
-            msg.len = 5;
-            msg.data[0] |= CAN_TS_T_FLOAT32;
-            f2b.f = *((float*)data_obj.data);
-            msg.data[1] = f2b.b[3];
-            msg.data[2] = f2b.b[2];
-            msg.data[3] = f2b.b[1];
-            msg.data[4] = f2b.b[0];
-            break;
-        case TS_T_INT32:
-            if (data_obj.detail == 0) {
-                    msg.len = 5;
-                    value = *((int*)data_obj.data);
-                    if (value >= 0) {
-                        msg.data[0] |= CAN_TS_T_POS_INT32;
-                        value_abs = abs(value);
-                    }
-                    else {
-                        msg.data[0] |= CAN_TS_T_NEG_INT32;
-                        value_abs = abs(value - 1);         // 0 is always pos integer
-                    }
-                    msg.data[1] = value_abs >> 24;
-                    msg.data[2] = value_abs >> 16;
-                    msg.data[3] = value_abs >> 8;
-                    msg.data[4] = value_abs;
-            }
-            else {
-                msg.len = 8;
-                msg.data[0] |= CAN_TS_T_DECFRAC;
-                msg.data[1] = 0x82;     // array of length 2
-
-                // detail in single byte value, valid: -24 ... 23
-                uint8_t exponent_abs = abs(data_obj.detail);
-                if (data_obj.detail >= 0 && data_obj.detail <= 23) {
-                    msg.data[2] = exponent_abs;
-                }
-                else if (data_obj.detail < 0 && data_obj.detail > -24) {
-                    msg.data[2] = (exponent_abs - 1) | 0x20;      // negative uint8
-                }
-
-                // value as positive or negative uint32
-                value = *((int*)data_obj.data);
-                if (value >= 0) {
-                    msg.data[3] = 0x1a;     // positive int32
-                    value_abs = abs(value);
-                }
-                else {
-                    msg.data[3] = 0x3a;     // negative int32
-                    value_abs = abs(value - 1);         // 0 is always pos integer
-                }
-                msg.data[4] = value_abs >> 24;
-                msg.data[5] = value_abs >> 16;
-                msg.data[6] = value_abs >> 8;
-                msg.data[7] = value_abs;
-            }
-            break;
-        case TS_T_BOOL:
-            msg.len = 1;
-            if (*((bool*)data_obj.data) == true) {
-                msg.data[0] = CAN_TS_T_TRUE;     // simple type: true
-            }
-            else {
-                msg.data[0] = CAN_TS_T_FALSE;     // simple type: false
-            }
-            break;
-        case TS_T_STRING:
-            break;
+    if (encode_len >= 0)
+    {
+        msg.len = encode_len;
+        can_tx_queue.enqueue(msg);
     }
-    can_tx_queue.enqueue(msg);
+    return (encode_len >= 0);
 }
+
+
+
 
 /**
  * returns number of can objects added to queue
  */
-int ThingSet::pub_msg_can(unsigned int channel)
+extern const int PUB_CHANNEL_CAN;
+
+int ThingSetCAN::pub()
 {
     int retval = 0;
+    ts_pub_channel_t* can_chan = ts.get_pub_channel(PUB_CHANNEL_CAN);
 
-    if (channel < num_channels)
+    if (can_chan != NULL)
     {
-        unsigned int num_elements = pub_channels[channel].num;
-
-        for (unsigned int element = 0; element < num_elements; element++)
+        for (unsigned int element = 0; element < can_chan->num; element++)
         {
-            const data_object_t *data_obj = get_data_object(pub_channels[channel].object_ids[element]);
-            if (data_obj == NULL || !(data_obj->access & TS_ACCESS_READ))
+            const data_object_t *data_obj = ts.get_data_object(can_chan->object_ids[element]);
+            if (data_obj != NULL && data_obj->access & TS_ACCESS_READ)
             {
-                continue;
+                if (ts_can.pub_object(*data_obj))
+                {
+                    retval++;
+                }  
             }
-            can_pub_msg(*data_obj);
-            retval++;  
         }
     }
     return retval;
 }
 
-void can_process_outbox()
+void ThingSetCAN::process_asap()
+{
+    process_outbox();
+}
+
+void ThingSetCAN::process_outbox()
 {
     int max_attempts = 15;
     while (!can_tx_queue.empty() && max_attempts > 0) {
@@ -230,7 +190,8 @@ void can_send_object_name(int data_obj_id, uint8_t can_dest_id)
 
     can_tx_queue.enqueue(msg);
 }
-
+#endif
+#if 0
 void can_process_inbox()
 {
     int max_attempts = 15;
@@ -286,7 +247,8 @@ void can_process_inbox()
         max_attempts--;
     }
 }
-
+#endif
+#if 0
 void can_receive() {
     CANMessage msg;
     while (can.read(msg)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,7 +116,7 @@ int main()
 #else // MPPT
     dcdc_init(&dcdc);
     half_bridge_init(PWM_FREQUENCY, 300, 12 / dcdc.hs_voltage_max, 0.97);       // lower duty limit might have to be adjusted dynamically depending on LS voltage
-#endif
+ #endif
 
     // Configuration from EEPROM
     data_objects_read_eeprom();
@@ -133,9 +133,10 @@ int main()
     calibrate_current_sensors();
 
     // Communication interfaces
+    #ifdef UART_SERIAL_ENABLED
     uart_serial_init(&serial);
+    #endif
     uext_init();
-
     init_watchdog(10);      // 10s should be enough for communication ports
 
     // Setup of DC/DC power stage

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -137,8 +137,9 @@ int main()
     #ifdef UART_SERIAL_ENABLED
     thingset_serial_init(&serial);
     #endif
+    
     #ifdef CAN_ENABLED
-    ts_can.init_hw();
+    ts_can.enable();
     #endif
 
     uext_init();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 #include "log.h"                // log data (error memory, min/max measurements, etc.)
 #include "data_objects.h"       // for access to internal data via ThingSet
 #include "thingset_serial.h"    // UART or USB serial communication
+#include "thingset_can.h"       // CAN bus communication
 
 Serial serial(PIN_SWD_TX, PIN_SWD_RX, "serial");
 
@@ -134,8 +135,12 @@ int main()
 
     // Communication interfaces
     #ifdef UART_SERIAL_ENABLED
-    uart_serial_init(&serial);
+    thingset_serial_init(&serial);
     #endif
+    #ifdef CAN_ENABLED
+    ts_can.init_hw();
+    #endif
+
     uext_init();
     init_watchdog(10);      // 10s should be enough for communication ports
 

--- a/src/pcbs/mppt_2420_lc_0v10.h
+++ b/src/pcbs/mppt_2420_lc_0v10.h
@@ -120,4 +120,10 @@ enum {
     ADC_CHSELR_CHSEL17 \
 )
 
+// defines for CAN BUS SUPPORT
+#define HAS_CAN 1
+#define PIN_CAN_RX    PB_8
+#define PIN_CAN_TX    PB_9
+#define PIN_CAN_STB PA_15
+
 #endif

--- a/src/thingset_can.h
+++ b/src/thingset_can.h
@@ -16,21 +16,31 @@
 #ifndef _THINGSET_CAN_H_
 #define _THINGSET_CAN_H_
 
+#ifdef CAN_ENABLED
 #include "data_objects.h"
+#include "can_msg_queue.h"
 
 class ThingSetCAN
 {
     public:
-        bool pub_object(const data_object_t& data_obj);
+        ThingSetCAN(uint8_t can_node_id);
+
         void process_asap();
         void process_1s();
 
-        void init_hw();
-        int  pub();
+        void enable();
 
     private:
+        bool pub_object(const data_object_t& data_obj);
+        int  pub();
         void process_outbox();
+
+        CANMsgQueue tx_queue;
+        // CANMsgQueue rx_queue;
+        uint8_t node_id;        
+
 };
 
 extern ThingSetCAN ts_can;
+#endif /* CAN_ENABLED */
 #endif

--- a/src/thingset_can.h
+++ b/src/thingset_can.h
@@ -1,0 +1,36 @@
+/* LibreSolar charge controller firmware
+ * Copyright (c) 2016-2019 Martin Jäger (www.libre.solar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef _THINGSET_CAN_H_
+#define _THINGSET_CAN_H_
+
+#include "data_objects.h"
+
+class ThingSetCAN
+{
+    public:
+        bool pub_object(const data_object_t& data_obj);
+        void process_asap();
+        void process_1s();
+
+        void init_hw();
+        int  pub();
+
+    private:
+        void process_outbox();
+};
+
+extern ThingSetCAN ts_can;
+#endif

--- a/src/thingset_serial.cpp
+++ b/src/thingset_serial.cpp
@@ -41,6 +41,11 @@ extern ThingSet ts;
 extern ts_pub_channel_t pub_channels[];
 extern const int pub_channel_serial;
 
+#ifdef CAN_ENABLED
+#include "thingset_can.h"
+#endif
+
+
 void thingset_serial_init(Serial* s)
 {
 #ifdef UART_SERIAL_ENABLED
@@ -59,7 +64,11 @@ void thingset_serial_process_asap()
 #ifdef USB_SERIAL_ENABLED
     usb_serial_process();
 #endif
+#ifdef CAN_ENABLED
+    ts_can.process_asap();
+#endif
 }
+
 
 void thingset_serial_process_1s()
 {
@@ -68,6 +77,10 @@ void thingset_serial_process_1s()
 #endif
 #ifdef USB_SERIAL_ENABLED
     usb_serial_pub();
+#endif
+
+#ifdef CAN_ENABLED
+    ts_can.process_1s();
 #endif
 
     fflush(stdout);
@@ -101,12 +114,16 @@ void uart_serial_isr()
         }
     }
 }
-
+#endif
+#ifdef UART_SERIAL_ENABLED
 void uart_serial_init(Serial* s)
 {
     ser_uart = s;
     s->attach(uart_serial_isr);
 }
+#endif
+#ifdef UART_SERIAL_ENABLED
+extern const int PUB_CHANNEL_SERIAL;
 
 void uart_serial_pub()
 {


### PR DESCRIPTION
Boots and runs CAN

Requires matching thingset-cpp library
The placement of the ts_can.process_asap/process_1s is a little hack,
but I did want to add even more ifdefs in the main method.
Renaming the functions could do the trick.
BTW, serial and CAN thingset can be run at the same time, no problems.