### PR TITLE
Fix to move data_objects to flash only

### DIFF
--- a/src/data_objects.cpp
+++ b/src/data_objects.cpp
@@ -41,10 +41,10 @@ extern dc_bus_t ls_bus;
 extern dc_bus_t load_bus;
 extern pwm_switch_t pwm_switch;
 
-const char* manufacturer = "Libre Solar";
-const char* device_type = DEVICE_TYPE;
-const char* hardware_version = HARDWARE_VERSION;
-const char* firmware_version = "0.1";
+const char* const manufacturer = "Libre Solar";
+const char* const device_type = DEVICE_TYPE;
+const char* const hardware_version = HARDWARE_VERSION;
+const char* const firmware_version = "0.1";
 uint32_t device_id = DEVICE_ID;      // from config.h
 
 extern uint32_t timestamp;


### PR DESCRIPTION
Without this, the 1296 byte long data_objects is stored in RAM
(after being copied from flash)