### PR TITLE
Reduced codesize: Switch to newlib-nano; Travis deploy on LibreSolar only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,5 @@ deploy:
     local_dir: html
     github_token: $GH_REPO_TOKEN
     on:
+        repo: LibreSolar/charge-controller-firmware
         branch: master

--- a/linker_flags_newlib-nano.py
+++ b/linker_flags_newlib-nano.py
@@ -1,0 +1,17 @@
+# Custom settings, as referred to as "extra_script" in platformio.ini
+#
+# See http://docs.platformio.org/en/latest/projectconf.html#extra-script
+# and https://docs.platformio.org/en/latest/projectconf/advanced_scripting.html#extra-linker-flags-without-wl-prefix
+#
+# We are setting the required linker flags for use of newlib-nano
+
+
+Import("env") 
+
+env.Append(
+            LINKFLAGS=[
+                "-Wl,-u,_printf_float",
+                "--specs=nano.specs",
+                "--specs=nosys.specs"
+            ]
+           )

--- a/platformio.ini
+++ b/platformio.ini
@@ -32,10 +32,15 @@ monitor_speed = 115200
 
 # Compiler settings
 build_flags =
+    -std=gnu++11
+    -fsingle-precision-constant
     -Wl,-Map,memory.map
     -D TURN_OFF_MBED_DEPRECATED_WARNING
     -D MBED_BUILD_PROFILE_RELEASE
 #    -D MBED_BUILD_PROFILE_DEBUG
+
+build_unflags = -std=g++98
+extra_scripts = linker_flags_newlib-nano.py
 
 lib_deps =
     https://github.com/ThingSet/thingset-cpp
@@ -54,8 +59,11 @@ upload_protocol = ${common.upload_protocol}
 monitor_speed = ${common.monitor_speed}
 build_flags = ${common.build_flags}
     -D MPPT_2420_LC_0V10
+
 lib_deps = ${common.lib_deps}
 lib_ignore = ${common.lib_ignore}
+build_unflags=-${common.build_unflags}
+extra_scripts = ${common.extra_scripts} 
 
 # https://github.com/LibreSolar/MPPT-1210-HUS/tree/586626f3d8
 [env:mppt-1210-hus-v0.2]
@@ -68,6 +76,8 @@ build_flags = ${common.build_flags}
     -D MPPT_1210_HUS_0V2
 lib_deps = ${common.lib_deps}
 lib_ignore = ${common.lib_ignore}
+build_unflags=-${common.build_unflags}
+extra_scripts = ${common.extra_scripts} 
 
 # https://github.com/LibreSolar/MPPT-1210-HUS/tree/63e5842671
 [env:mppt-1210-hus-v0.4]
@@ -80,6 +90,8 @@ build_flags = ${common.build_flags}
     -D MPPT_1210_HUS_0V4
 lib_deps = ${common.lib_deps}
 lib_ignore = ${common.lib_ignore}
+build_unflags=-${common.build_unflags}
+extra_scripts = ${common.extra_scripts} 
 
 [env:mppt-1210-hus-v0.6]
 platform = ${common.platform}
@@ -91,6 +103,8 @@ build_flags = ${common.build_flags}
     -D MPPT_1210_HUS_0V6
 lib_deps = ${common.lib_deps}
 lib_ignore = ${common.lib_ignore}
+build_unflags=-${common.build_unflags}
+extra_scripts = ${common.extra_scripts} 
 
 # initial test version (obsolete)
 [env:pwm-2420-lus-v0.1]
@@ -103,6 +117,8 @@ build_flags = ${common.build_flags}
     -D PWM_2420_LUS_0V1
 lib_deps = ${common.lib_deps}
 lib_ignore = ${common.lib_ignore}
+build_unflags=-${common.build_unflags}
+extra_scripts = ${common.extra_scripts} 
 
 # https://github.com/LibreSolar/PWM-2420-LUS
 [env:pwm-2420-lus-v0.2]
@@ -115,12 +131,16 @@ build_flags = ${common.build_flags}
     -D PWM_2420_LUS_0V2
 lib_deps = ${common.lib_deps}
 lib_ignore = ${common.lib_ignore}
+build_unflags=-${common.build_unflags}
+extra_scripts = ${common.extra_scripts} 
 
 [env:unit-test-native]
 platform = native
 build_flags =
+    -std=gnu++11
     -D LITTLE_ENDIAN
     -D UNIT_TEST
 # include src directory (otherwise unit-tests will only include lib directory)
 test_build_project_src = true
 lib_ignore = USB, mbed-USBDevice, mbed-mbedtls, USBSerial, ESP32, Adafruit_GFX
+build_unflags=-${common.build_unflags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -39,7 +39,7 @@ build_flags =
     -D MBED_BUILD_PROFILE_RELEASE
 #    -D MBED_BUILD_PROFILE_DEBUG
 
-build_unflags = -std=g++98
+build_unflags = -std=gnu++98
 extra_scripts = linker_flags_newlib-nano.py
 
 lib_deps =
@@ -62,7 +62,7 @@ build_flags = ${common.build_flags}
 
 lib_deps = ${common.lib_deps}
 lib_ignore = ${common.lib_ignore}
-build_unflags=-${common.build_unflags}
+build_unflags= ${common.build_unflags}
 extra_scripts = ${common.extra_scripts} 
 
 # https://github.com/LibreSolar/MPPT-1210-HUS/tree/586626f3d8
@@ -76,7 +76,7 @@ build_flags = ${common.build_flags}
     -D MPPT_1210_HUS_0V2
 lib_deps = ${common.lib_deps}
 lib_ignore = ${common.lib_ignore}
-build_unflags=-${common.build_unflags}
+build_unflags= ${common.build_unflags}
 extra_scripts = ${common.extra_scripts} 
 
 # https://github.com/LibreSolar/MPPT-1210-HUS/tree/63e5842671
@@ -90,7 +90,7 @@ build_flags = ${common.build_flags}
     -D MPPT_1210_HUS_0V4
 lib_deps = ${common.lib_deps}
 lib_ignore = ${common.lib_ignore}
-build_unflags=-${common.build_unflags}
+build_unflags= ${common.build_unflags}
 extra_scripts = ${common.extra_scripts} 
 
 [env:mppt-1210-hus-v0.6]
@@ -103,7 +103,7 @@ build_flags = ${common.build_flags}
     -D MPPT_1210_HUS_0V6
 lib_deps = ${common.lib_deps}
 lib_ignore = ${common.lib_ignore}
-build_unflags=-${common.build_unflags}
+build_unflags= ${common.build_unflags}
 extra_scripts = ${common.extra_scripts} 
 
 # initial test version (obsolete)
@@ -117,7 +117,7 @@ build_flags = ${common.build_flags}
     -D PWM_2420_LUS_0V1
 lib_deps = ${common.lib_deps}
 lib_ignore = ${common.lib_ignore}
-build_unflags=-${common.build_unflags}
+build_unflags= ${common.build_unflags}
 extra_scripts = ${common.extra_scripts} 
 
 # https://github.com/LibreSolar/PWM-2420-LUS
@@ -131,7 +131,7 @@ build_flags = ${common.build_flags}
     -D PWM_2420_LUS_0V2
 lib_deps = ${common.lib_deps}
 lib_ignore = ${common.lib_ignore}
-build_unflags=-${common.build_unflags}
+build_unflags= ${common.build_unflags}
 extra_scripts = ${common.extra_scripts} 
 
 [env:unit-test-native]
@@ -143,4 +143,4 @@ build_flags =
 # include src directory (otherwise unit-tests will only include lib directory)
 test_build_project_src = true
 lib_ignore = USB, mbed-USBDevice, mbed-mbedtls, USBSerial, ESP32, Adafruit_GFX
-build_unflags=-${common.build_unflags}
+build_unflags= ${common.build_unflags}


### PR DESCRIPTION
Figured out how to switch to newlib-nano in a simple way.
Reduced build size by about 29k. Applied this to all STM32 builds.
Please test with the STM32L072 hardware, I don't have one of those,
only STM32F072

Also "upgraded" the compiler accepted language standard to gnu c++11 (from gnu++98).

And finally defined that all floating point constants are to be treated
as "floats" and not as double (which is the default). Reduces the number
of implicit double promotions almost to the required minimum.

In some places the double functions are applied to floats which also
causes some unwanted time and code growth. But this is not fixed yet.