### PR TITLE
Fix for #44 (Wrong DCDC power calculation)

### DIFF
--- a/src/adc_dma.cpp
+++ b/src/adc_dma.cpp
@@ -104,6 +104,7 @@ void update_measurements(Dcdc *dcdc, Charger *charger, DcBus *hs, DcBus *ls, DcB
         ADC_GAIN_V_BAT / 1000.0;
 
     load_bus->voltage = ls->voltage;
+    dcdc->ls_voltage = ls->voltage;
 
     hs->voltage =
         (float)(((adc_filtered[ADC_POS_V_SOLAR] >> (4 + ADC_FILTER_CONST)) * vcc) / 4096) *

--- a/src/dcdc.cpp
+++ b/src/dcdc.cpp
@@ -49,7 +49,7 @@ void dcdc_init(Dcdc *dcdc)
 // returns if output power should be increased (1), decreased (-1) or switched off (0)
 int _dcdc_output_control(Dcdc *dcdc, DcBus *out, DcBus *in)
 {
-    float dcdc_power_new = out->voltage * out->current;
+    float dcdc_power_new = fabs(dcdc->ls_voltage * dcdc->ls_current); // voltage always positive, current is negative in boost mode
     static int pwm_delta = 1;
 
     //printf("P: %.2f, P_prev: %.2f, v_in: %.2f, v_out: %.2f, i_in: %.2f, i_out: %.2f, i_max: %.2f, PWM: %.1f, chg_en: %d\n",

--- a/src/dcdc.h
+++ b/src/dcdc.h
@@ -65,6 +65,7 @@ typedef struct {
 
     // actual measurements
     float ls_current;           ///< Low-side (inductor) current
+    float ls_voltage;           ///< Low-side (inductor) voltage
     float temp_mosfets;         ///< MOSFET temperature measurement (if existing)
 
     // current state


### PR DESCRIPTION
The dcdc power has to use the dcdc current and voltage instead of the
output voltage (which can be low side - buck or high side - boost) and
the dcdc current instead of the out current. See #44 for the discussion
on this issue