### PR TITLE
Thingset device C++ refactoring

### DIFF
--- a/linker_flags_newlib-nano.py
+++ b/linker_flags_newlib-nano.py
@@ -13,5 +13,6 @@ env.Append(
                 "-Wl,-u,_printf_float",
                 "--specs=nano.specs",
                 "--specs=nosys.specs"
-            ]
-           )
+            ])
+
+env.Append( CXXFLAGS=[ "-Wno-register" ] )

--- a/platformio.ini
+++ b/platformio.ini
@@ -65,59 +65,34 @@ board = nucleo_f072rb
 build_flags = ${env.build_flags}
     -D MPPT_2420_LC_0V10
 
-lib_deps = ${common.lib_deps}
-lib_ignore = ${common.lib_ignore}
-build_unflags= ${common.build_unflags}
-extra_scripts = ${common.extra_scripts} 
-
 # https://github.com/LibreSolar/MPPT-1210-HUS/tree/586626f3d8
 [env:mppt-1210-hus-v0.2]
 board = nucleo_f072rb
 build_flags = ${env.build_flags}
     -D MPPT_1210_HUS_0V2
-lib_deps = ${common.lib_deps}
-lib_ignore = ${common.lib_ignore}
-build_unflags= ${common.build_unflags}
-extra_scripts = ${common.extra_scripts} 
 
 # https://github.com/LibreSolar/MPPT-1210-HUS/tree/63e5842671
 [env:mppt-1210-hus-v0.4]
 board = nucleo_l073rz
 build_flags = ${env.build_flags}
     -D MPPT_1210_HUS_0V4
-lib_deps = ${common.lib_deps}
-lib_ignore = ${common.lib_ignore}
-build_unflags= ${common.build_unflags}
-extra_scripts = ${common.extra_scripts} 
 
 [env:mppt-1210-hus-v0.6]
 board = nucleo_l073rz
 build_flags = ${env.build_flags}
     -D MPPT_1210_HUS_0V6
-lib_deps = ${common.lib_deps}
-lib_ignore = ${common.lib_ignore}
-build_unflags= ${common.build_unflags}
-extra_scripts = ${common.extra_scripts} 
 
 # initial test version (obsolete)
 [env:pwm-2420-lus-v0.1]
 board = nucleo_l073rz
 build_flags = ${env.build_flags}
     -D PWM_2420_LUS_0V1
-lib_deps = ${common.lib_deps}
-lib_ignore = ${common.lib_ignore}
-build_unflags= ${common.build_unflags}
-extra_scripts = ${common.extra_scripts} 
 
 # https://github.com/LibreSolar/PWM-2420-LUS
 [env:pwm-2420-lus-v0.2]
 board = nucleo_l073rz
 build_flags = ${env.build_flags}
     -D PWM_2420_LUS_0V2
-lib_deps = ${common.lib_deps}
-lib_ignore = ${common.lib_ignore}
-build_unflags= ${common.build_unflags}
-extra_scripts = ${common.extra_scripts} 
 
 [env:unit-test-native]
 platform = native
@@ -130,4 +105,3 @@ build_flags =
 test_build_project_src = true
 lib_ignore = USB, mbed-USBDevice, mbed-mbedtls, USBSerial, ESP32, Adafruit_GFX, SX1276GenericLib
 extra_scripts =
-build_unflags= ${common.build_unflags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,8 @@ monitor_speed = 115200
 
 # Compiler settings
 build_flags =
-    -std=gnu++11
+    -std=gnu++1z
+    -Wno-register
     -fsingle-precision-constant
     -Wl,-Map,memory.map
     -D TURN_OFF_MBED_DEPRECATED_WARNING

--- a/platformio.ini
+++ b/platformio.ini
@@ -38,7 +38,7 @@ monitor_speed = 115200
 
 # Compiler settings
 build_flags =
-    -std=gnu++1z
+    -std=gnu++17
     -Wno-register
     -fsingle-precision-constant
     -Wl,-Map,memory.map

--- a/platformio.ini
+++ b/platformio.ini
@@ -64,34 +64,59 @@ board = nucleo_f072rb
 build_flags = ${env.build_flags}
     -D MPPT_2420_LC_0V10
 
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_unflags= ${common.build_unflags}
+extra_scripts = ${common.extra_scripts} 
+
 # https://github.com/LibreSolar/MPPT-1210-HUS/tree/586626f3d8
 [env:mppt-1210-hus-v0.2]
 board = nucleo_f072rb
 build_flags = ${env.build_flags}
     -D MPPT_1210_HUS_0V2
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_unflags= ${common.build_unflags}
+extra_scripts = ${common.extra_scripts} 
 
 # https://github.com/LibreSolar/MPPT-1210-HUS/tree/63e5842671
 [env:mppt-1210-hus-v0.4]
 board = nucleo_l073rz
 build_flags = ${env.build_flags}
     -D MPPT_1210_HUS_0V4
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_unflags= ${common.build_unflags}
+extra_scripts = ${common.extra_scripts} 
 
 [env:mppt-1210-hus-v0.6]
 board = nucleo_l073rz
 build_flags = ${env.build_flags}
     -D MPPT_1210_HUS_0V6
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_unflags= ${common.build_unflags}
+extra_scripts = ${common.extra_scripts} 
 
 # initial test version (obsolete)
 [env:pwm-2420-lus-v0.1]
 board = nucleo_l073rz
 build_flags = ${env.build_flags}
     -D PWM_2420_LUS_0V1
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_unflags= ${common.build_unflags}
+extra_scripts = ${common.extra_scripts} 
 
 # https://github.com/LibreSolar/PWM-2420-LUS
 [env:pwm-2420-lus-v0.2]
 board = nucleo_l073rz
 build_flags = ${env.build_flags}
     -D PWM_2420_LUS_0V2
+lib_deps = ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+build_unflags= ${common.build_unflags}
+extra_scripts = ${common.extra_scripts} 
 
 [env:unit-test-native]
 platform = native
@@ -104,3 +129,4 @@ build_flags =
 test_build_project_src = true
 lib_ignore = USB, mbed-USBDevice, mbed-mbedtls, USBSerial, ESP32, Adafruit_GFX, SX1276GenericLib
 extra_scripts =
+build_unflags= ${common.build_unflags}

--- a/src/adc_dma.cpp
+++ b/src/adc_dma.cpp
@@ -104,6 +104,7 @@ void update_measurements(Dcdc *dcdc, Charger *charger, DcBus *hs, DcBus *ls, DcB
         ADC_GAIN_V_BAT / 1000.0;
 
     load_bus->voltage = ls->voltage;
+    dcdc->ls_voltage = ls->voltage;
 
     hs->voltage =
         (float)(((adc_filtered[ADC_POS_V_SOLAR] >> (4 + ADC_FILTER_CONST)) * vcc) / 4096) *

--- a/src/dcdc.cpp
+++ b/src/dcdc.cpp
@@ -49,7 +49,7 @@ void dcdc_init(Dcdc *dcdc)
 // returns if output power should be increased (1), decreased (-1) or switched off (0)
 int _dcdc_output_control(Dcdc *dcdc, DcBus *out, DcBus *in)
 {
-    float dcdc_power_new = out->voltage * out->current;
+    float dcdc_power_new = dcdc->ls_voltage * dcdc->ls_current;
     static int pwm_delta = 1;
 
     //printf("P: %.2f, P_prev: %.2f, v_in: %.2f, v_out: %.2f, i_in: %.2f, i_out: %.2f, i_max: %.2f, PWM: %.1f, chg_en: %d\n",

--- a/src/dcdc.h
+++ b/src/dcdc.h
@@ -65,6 +65,7 @@ typedef struct {
 
     // actual measurements
     float ls_current;           ///< Low-side (inductor) current
+    float ls_voltage;           ///< Low-side (inductor) voltage
     float temp_mosfets;         ///< MOSFET temperature measurement (if existing)
 
     // current state

--- a/src/interface_can.cpp
+++ b/src/interface_can.cpp
@@ -32,13 +32,8 @@
 #include "thingset.h"
 #include "thingset_can.h"
 
-extern Serial serial;
-
 #ifndef CAN_SPEED
 #define CAN_SPEED 250000    // 250 kHz
-#endif
-#ifndef CAN_NODE_ID
-#define CAN_NODE_ID 10
 #endif
 
 class ThingSetCAN_Device
@@ -62,9 +57,7 @@ DigitalOut can_disable(PIN_CAN_STB);
 
 extern ThingSet ts;
 
-ThingSetCAN ts_can(CAN_NODE_ID);
-
-ThingSetCAN::ThingSetCAN(uint8_t can_node_id): node_id(can_node_id)
+ThingSetCAN::ThingSetCAN(uint8_t can_node_id, const unsigned int c): node_id(can_node_id), channel(c)
 {
     can_disable = 1; // we disable the transceiver
     can.mode(CAN::Normal);
@@ -81,8 +74,8 @@ void ThingSetCAN::enable()
 
 void ThingSetCAN::process_1s()
 {
-    ts_can.pub();
-    ts_can.process_asap();
+    pub();
+    process_asap();
 }
 
 bool ThingSetCAN::pub_object(const data_object_t& data_obj)
@@ -107,12 +100,10 @@ bool ThingSetCAN::pub_object(const data_object_t& data_obj)
 /**
  * returns number of can objects added to queue
  */
-extern const int PUB_CHANNEL_CAN;
-
 int ThingSetCAN::pub()
 {
     int retval = 0;
-    ts_pub_channel_t* can_chan = ts.get_pub_channel(PUB_CHANNEL_CAN);
+    ts_pub_channel_t* can_chan = ts.get_pub_channel(channel);
 
     if (can_chan != NULL)
     {
@@ -121,7 +112,7 @@ int ThingSetCAN::pub()
             const data_object_t *data_obj = ts.get_data_object(can_chan->object_ids[element]);
             if (data_obj != NULL && data_obj->access & TS_ACCESS_READ)
             {
-                if (ts_can.pub_object(*data_obj))
+                if (pub_object(*data_obj))
                 {
                     retval++;
                 }  

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -164,7 +164,7 @@ int main()
     control_timer_start(CONTROL_FREQUENCY);
     wait(0.1);  // necessary to prevent MCU from randomly getting stuck here if PV panel is connected before battery
 
-    sleep_manager_lock_deep_sleep();
+    // sleep_manager_lock_deep_sleep();
 
     // the main loop is suitable for slow tasks like communication (even blocking wait allowed)
     time_t last_call = timestamp;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -164,7 +164,13 @@ int main()
     control_timer_start(CONTROL_FREQUENCY);
     wait(0.1);  // necessary to prevent MCU from randomly getting stuck here if PV panel is connected before battery
 
-    // sleep_manager_lock_deep_sleep();
+
+    sleep_manager_lock_deep_sleep(); // required to have sleep returning. 
+    /*  
+        The mBed Serial class calls this internal during "attach", this is why it work with ThingSet Serial enabled even
+        without this statement. Might be an issue of the particular STM32F072 mBed code or may affect
+        also STM32L073 platforms on mBed
+    */
 
     // the main loop is suitable for slow tasks like communication (even blocking wait allowed)
     time_t last_call = timestamp;

--- a/src/thingset_can.h
+++ b/src/thingset_can.h
@@ -37,11 +37,19 @@ class ThingSetCAN: public ThingSetDevice
         bool pub_object(const data_object_t& data_obj);
         int  pub();
         void process_outbox();
+        
+    #if defined(CAN_RECEIVE)
+        void process_inbox();
+        void process_input();
+        void send_object_name(int data_obj_id, uint8_t can_dest_id);
+        CANMsgQueue rx_queue;
+    #endif
 
         CANMsgQueue tx_queue;
-        // CANMsgQueue rx_queue;
         uint8_t node_id;        
         const unsigned int channel;
+        CAN can;
+        DigitalOut can_disable;
 };
 #endif /* CAN_ENABLED */
 #endif

--- a/src/thingset_device.cpp
+++ b/src/thingset_device.cpp
@@ -1,0 +1,89 @@
+/* LibreSolar charge controller firmware
+ * Copyright (c) 2016-2019 Martin Jäger (www.libre.solar)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef UNIT_TEST
+
+#include "config.h"
+#include "mbed.h"
+#include "thingset.h"
+#include "thingset_device.h"
+
+/*
+ * Construct all global ThingSetDevices here. 
+ * All of these are added to the list of devices
+ * for later processing in the normal operation
+ */
+
+#ifdef CAN_ENABLED
+    #include "thingset_can.h"
+    extern const unsigned int PUB_CHANNEL_CAN;
+    #ifndef CAN_NODE_ID
+        #define CAN_NODE_ID 10
+    #endif
+    ThingSetCAN ts_can(CAN_NODE_ID, PUB_CHANNEL_CAN);
+#endif
+
+#ifdef UART_SERIAL_ENABLED
+    #include "thingset_serial.h"
+    extern const int pub_channel_serial;
+    extern Serial serial;
+
+    ThingSetSerial ts_uart(serial, pub_channel_serial);
+#endif /* UART_SERIAL_ENABLED */
+
+
+#ifdef USB_SERIAL_ENABLED
+    #include "thingset_serial.h"
+    #include "USBSerial.h"
+    extern const int pub_channel_serial;
+
+    USBSerial ser_usb(0x1f00, 0x2012, 0x0001,  false);    // connection is not blocked when USB is not plugged in
+
+    ThingSetSerial ts_usb(ser_usb, pub_channel_serial);
+#endif /* USB_SERIAL_ENABLED */
+
+
+// we use ifdef here in order to avoid using some dynamically 
+// allocated list. Only std::vector works with this code if NO devices are enabled
+// std::array and also plain C arrays work if at least one array element is there.
+ 
+std::vector<ThingSetDevice*> ThingSetDeviceManager::devices[] =
+{
+#ifdef UART_SERIAL_ENABLED
+    &ts_uart,
+#endif
+#ifdef USB_SERIAL_ENABLED
+    &ts_usb,
+#endif
+#ifdef CAN_ENABLED
+    &ts_can,
+#endif
+};
+
+// run the respective function on all objects in the "devices" list
+// use the c++11 lambda expressions here for the for_each loop, keeps things compact 
+
+void ThingSetDeviceManager::process_asap()  { for_each(std::begin(devices),std::end(devices), [](ThingSetDevice* dev){ dev->process_asap(); }); }
+void ThingSetDeviceManager::enable()        { for_each(std::begin(devices),std::end(devices), [](ThingSetDevice* dev){ dev->enable(); }); }
+void ThingSetDeviceManager::process_1s()    
+{ 
+    for_each(std::begin(devices),std::end(devices), [](ThingSetDevice* dev) { dev->process_1s(); });     
+    fflush(stdout);
+}
+
+ThingSetDeviceManager ts_devices;
+
+#endif /* UNIT_TEST */

--- a/src/thingset_device.cpp
+++ b/src/thingset_device.cpp
@@ -60,7 +60,7 @@
 // allocated list. Only std::vector works with this code if NO devices are enabled
 // std::array and also plain C arrays work if at least one array element is there.
  
-std::vector<ThingSetDevice*> ThingSetDeviceManager::devices[] =
+std::vector<ThingSetDevice*> ThingSetDeviceManager::devices =
 {
 #ifdef UART_SERIAL_ENABLED
     &ts_uart,
@@ -76,13 +76,9 @@ std::vector<ThingSetDevice*> ThingSetDeviceManager::devices[] =
 // run the respective function on all objects in the "devices" list
 // use the c++11 lambda expressions here for the for_each loop, keeps things compact 
 
-void ThingSetDeviceManager::process_asap()  { for_each(std::begin(devices),std::end(devices), [](ThingSetDevice* dev){ dev->process_asap(); }); }
-void ThingSetDeviceManager::enable()        { for_each(std::begin(devices),std::end(devices), [](ThingSetDevice* dev){ dev->enable(); }); }
-void ThingSetDeviceManager::process_1s()    
-{ 
-    for_each(std::begin(devices),std::end(devices), [](ThingSetDevice* dev) { dev->process_1s(); });     
-    fflush(stdout);
-}
+void ThingSetDeviceManager::process_asap()  { for_each(std::begin(devices),std::end(devices), [](ThingSetDevice* dev) { dev->process_asap(); }); }
+void ThingSetDeviceManager::enable()        { for_each(std::begin(devices),std::end(devices), [](ThingSetDevice* dev) { dev->enable();       }); }
+void ThingSetDeviceManager::process_1s()    { for_each(std::begin(devices),std::end(devices), [](ThingSetDevice* dev) { dev->process_1s();   }); }
 
 ThingSetDeviceManager ts_devices;
 

--- a/src/thingset_device.h
+++ b/src/thingset_device.h
@@ -13,35 +13,31 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef _THINGSET_CAN_H_
-#define _THINGSET_CAN_H_
+#ifndef _THINGSET_DEVICE_H_
+#define _THINGSET_DEVICE_H_
 
-#include "config.h"
+#include <vector>
 
-#ifdef CAN_ENABLED
-#include "data_objects.h"
-#include "can_msg_queue.h"
-#include "thingset_device.h"
-
-class ThingSetCAN: public ThingSetDevice
+class ThingSetDevice
 {
     public:
-        ThingSetCAN(uint8_t can_node_id, const unsigned int c);
-
-        void process_asap();
-        void process_1s();
-
-        void enable();
-
+        virtual void process_asap()  {};
+        virtual void process_1s() {};
+        virtual void enable() {};
     private:
-        bool pub_object(const data_object_t& data_obj);
-        int  pub();
-        void process_outbox();
 
-        CANMsgQueue tx_queue;
-        // CANMsgQueue rx_queue;
-        uint8_t node_id;        
-        const unsigned int channel;
 };
-#endif /* CAN_ENABLED */
+
+class ThingSetDeviceManager: public ThingSetDevice
+{
+    public:
+        virtual void process_asap();
+        virtual void process_1s();
+
+        virtual void enable();
+    private:
+        static std::vector<ThingSetDevice*> devices;
+};
+
+extern ThingSetDeviceManager ts_devices;
 #endif

--- a/src/thingset_serial.cpp
+++ b/src/thingset_serial.cpp
@@ -16,197 +16,63 @@
 
 #ifndef UNIT_TEST
 
+#include "config.h"
 #include "mbed.h"
 #include "thingset.h"
-#include "config.h"
-
 #include "thingset_serial.h"
 
-#ifdef USB_SERIAL_ENABLED
-#include "USBSerial.h"
-USBSerial ser_usb(0x1f00, 0x2012, 0x0001,  false);    // connection is not blocked when USB is not plugged in
-uint8_t buf_req_usb[500];
-size_t req_usb_pos = 0;
-#endif
-
-#ifdef UART_SERIAL_ENABLED
-Serial* ser_uart;
-uint8_t buf_req_uart[500];
-size_t req_uart_pos = 0;
-#endif
-
-static uint8_t buf_resp[1000];           // only one response buffer needed for USB and UART
+uint8_t ThingSetStream::buf_resp[1000];
 
 extern ThingSet ts;
-extern ts_pub_channel_t pub_channels[];
-extern const int pub_channel_serial;
 
-#ifdef CAN_ENABLED
-#include "thingset_can.h"
-#endif
-
-
-void thingset_serial_init(Serial* s)
+void ThingSetStream::process_1s()
 {
-#ifdef UART_SERIAL_ENABLED
-    uart_serial_init(s);
-#endif
-#ifdef USB_SERIAL_ENABLED
-    usb_serial_init();
-#endif
-}
-
-void thingset_serial_process_asap()
-{
-#ifdef UART_SERIAL_ENABLED
-    uart_serial_process();
-#endif
-#ifdef USB_SERIAL_ENABLED
-    usb_serial_process();
-#endif
-#ifdef CAN_ENABLED
-    ts_can.process_asap();
-#endif
-}
-
-
-void thingset_serial_process_1s()
-{
-#ifdef UART_SERIAL_ENABLED
-    uart_serial_pub();
-#endif
-#ifdef USB_SERIAL_ENABLED
-    usb_serial_pub();
-#endif
-
-#ifdef CAN_ENABLED
-    ts_can.process_1s();
-#endif
-
-    fflush(stdout);
-}
-
-#ifdef UART_SERIAL_ENABLED
-
-static bool uart_serial_command_flag = false;
-
-void uart_serial_isr()
-{
-    while (ser_uart->readable() && uart_serial_command_flag == false) {
-        if (req_uart_pos < sizeof(buf_req_uart)) {
-            buf_req_uart[req_uart_pos] = ser_uart->getc();
-
-            if (buf_req_uart[req_uart_pos] == '\n') {
-                if (req_uart_pos > 0 && buf_req_uart[req_uart_pos-1] == '\r')
-                    buf_req_uart[req_uart_pos-1] = '\0';
-                else
-                    buf_req_uart[req_uart_pos] = '\0';
-
-                // start processing
-                uart_serial_command_flag = true;
-            }
-            else if (req_uart_pos > 0 && buf_req_uart[req_uart_pos] == '\b') { // backspace
-                req_uart_pos--;
-            }
-            else {
-                req_uart_pos++;
-            }
-        }
+    if (ts.get_pub_channel(channel)->enabled) {
+        ts.pub_msg_json((char *)buf_resp, sizeof(buf_resp), channel);
+        stream->puts((const char*)buf_resp);
+        stream->putc('\n');
     }
-}
-#endif
-#ifdef UART_SERIAL_ENABLED
-void uart_serial_init(Serial* s)
-{
-    ser_uart = s;
-    s->attach(uart_serial_isr);
-}
-#endif
-#ifdef UART_SERIAL_ENABLED
-extern const int PUB_CHANNEL_SERIAL;
-
-void uart_serial_pub()
-{
-    if (pub_channels[pub_channel_serial].enabled) {
-        ts.pub_msg_json((char *)buf_resp, sizeof(buf_resp), 0);
-        ser_uart->printf("%s\n", buf_resp);
-    }
+    stream->puts(".\n");
 }
 
-void uart_serial_process()
+void ThingSetStream::process_asap()
 {
-    if (uart_serial_command_flag) {
-        if (req_uart_pos > 1) {
-            ser_uart->printf("Received Request (%d bytes): %s\n", strlen((char *)buf_req_uart), buf_req_uart);
-            ts.process(buf_req_uart, strlen((char *)buf_req_uart), buf_resp, sizeof(buf_resp));
-            ser_uart->printf("%s\n", buf_resp);
+    if (command_flag) {
+        if (req_pos > 1) {
+            stream->printf("Received Request (%d bytes): %s\n", strlen((char *)buf_req), buf_req);
+            ts.process(buf_req, strlen((char *)buf_req), buf_resp, sizeof(buf_resp));
+            stream->puts((const char*)buf_resp);
+            stream->putc('\n');
         }
 
         // start listening for new commands
-        uart_serial_command_flag = false;
-        req_uart_pos = 0;
+        command_flag = false;
+        req_pos = 0;
     }
 }
 
-#endif /* UART_SERIAL_ENABLED */
-
-
-#ifdef USB_SERIAL_ENABLED
-
-static bool usb_serial_command_flag = false;
-
-void usb_serial_isr()
+void ThingSetStream::process_input()
 {
-    while (ser_usb.readable() && usb_serial_command_flag == false) {
-        if (req_usb_pos < 100) {
-            buf_req_usb[req_usb_pos] = ser_usb.getc();
-            //ser_usb->putc(req_usb.data[req_usb_pos]);     // echo back the character
-            if (buf_req_usb[req_usb_pos] == '\n') {
-                if (req_usb_pos > 0 && buf_req_usb[req_usb_pos-1] == '\r')
-                    buf_req_usb[req_usb_pos-1] = '\0';
+        while (stream->readable() && command_flag == false) {
+        if (req_pos < sizeof(buf_req)) {
+            buf_req[req_pos] = stream->getc();
+
+            if (buf_req[req_pos] == '\n') {
+                if (req_pos > 0 && buf_req[req_pos-1] == '\r')
+                    buf_req[req_pos-1] = '\0';
                 else
-                    buf_req_usb[req_usb_pos] = '\0';
-                req_usb_pos = 0;
-                usb_serial_command_flag = true;
+                    buf_req[req_pos] = '\0';
+
+                // start processing
+                command_flag = true;
             }
-            else if (req_usb_pos > 0 && buf_req_usb[req_usb_pos] == '\b') { // backspace
-                req_usb_pos--;
+            else if (req_pos > 0 && buf_req[req_pos] == '\b') { // backspace
+                req_pos--;
             }
             else {
-                req_usb_pos++;
+                req_pos++;
             }
         }
     }
 }
-
-void usb_serial_init()
-{
-    ser_usb.attach(usb_serial_isr);
-//    buf_req_usb = buf_req_uart;
-}
-
-void usb_serial_process()
-{
-    if (usb_serial_command_flag) {
-        //ser->printf("Received Command: %s\n", buf_serial);
-        //int len_req = sizeof(req_usb.data);
-        if (req_usb_pos > 1) {
-            ser_usb.printf("Received Request (%d bytes): %s\n", strlen((char *)buf_req_usb), buf_req_usb);
-            ts.process(buf_req_usb, strlen((char *)buf_req_usb), buf_resp, sizeof(buf_resp));
-            ser_usb.printf("%s\n", buf_resp);
-        }
-        usb_serial_command_flag = false;
-        req_usb_pos = 0;
-    }
-}
-
-void usb_serial_pub() {
-    if (pub_channels[pub_channel_serial].enabled) {
-        ts.pub_msg_json((char *)buf_resp, sizeof(buf_resp), pub_channel_serial);
-        ser_usb.printf("%s\n", buf_resp);
-    }
-}
-
-#endif /* USB_SERIAL_ENABLED */
-
 #endif /* UNIT_TEST */

--- a/src/thingset_serial.cpp
+++ b/src/thingset_serial.cpp
@@ -58,7 +58,7 @@ void ThingSetStream::process_asap()
  */
 void ThingSetStream::process_input()
 {
-    while (stream->readable() && command_flag == false) {
+    while (readable() && command_flag == false) {
 
         int c = stream->getc();
 

--- a/src/thingset_serial.h
+++ b/src/thingset_serial.h
@@ -41,8 +41,8 @@ class ThingSetStream: public ThingSetDevice
     private:
         Stream* stream;
 
-        static uint8_t buf_resp[1000];           // only one response buffer needed for all objects
-        uint8_t buf_req[500];
+        static char buf_resp[1000];           // only one response buffer needed for all objects
+        char buf_req[500];
         size_t req_pos = 0;
         bool command_flag = false;
 };
@@ -54,7 +54,7 @@ template<typename T> class ThingSetSerial: public ThingSetStream
 
         virtual void enable() { {
             Callback<void()>  cb([this]() -> void { this->process_input();});
-            // ser->attach(cb);
+            ser->attach(cb);
         }
 }
         

--- a/src/thingset_serial.h
+++ b/src/thingset_serial.h
@@ -38,6 +38,11 @@ class ThingSetStream: public ThingSetDevice
         virtual void process_input(); // this is called from the ISR typically
         const unsigned int channel;
 
+        virtual bool readable()
+        {
+            return stream->readable();
+        }
+
     private:
         Stream* stream;
 
@@ -50,15 +55,20 @@ class ThingSetStream: public ThingSetDevice
 template<typename T> class ThingSetSerial: public ThingSetStream
 {
     public:
-        ThingSetSerial(T& s, const unsigned int c): ThingSetStream(s,c), ser(&s) {}
+        ThingSetSerial(T& s, const unsigned int c): ThingSetStream(s,c), ser(s) {}
 
-        virtual void enable() { {
+        void enable() {
             Callback<void()>  cb([this]() -> void { this->process_input();});
-            ser->attach(cb);
+            ser.attach(cb);
         }
-}
         
     private:
-        T* ser;
+        bool readable()
+        {
+            return ser.readable();
+        }
+        
+    private:
+        T& ser;
 };
 #endif /* THINGSET_SERIAL_H */


### PR DESCRIPTION
Rewrote the thingset device using classes and objects to be easier to use and extend. 
- Any number and combination of thingset device can be configured in (including no device).
No #ifdefs in the main.cpp anymore.
Removed duplicated code for serial based thingset devices (USB/"real serial"), now implemented in a shared class (ThingSetStream).
Tried to keep overhead as minimal as possible.
There are a couple of more (lambda functions) or less modern C++ concepts (templates) used to achieve this.

Cons: Requires gcc C++17 mode which does not like "register" keyword. Unfortunately platformio does not allow setting CXXFLAG for libraries in the extra_scripts. This forces us to use -Wno-register as global compile setting, which in turn causes the C compiler to issue a warning about a C++ only warning flag...  Better than leaving it out and have the C++ compiler complain about "register" keyword use. Does not affect the code, works without problems.
 
