### PR TITLE
Increase Efficiency: Use MPPT mode more often

### DIFF
--- a/linker_flags_newlib-nano.py
+++ b/linker_flags_newlib-nano.py
@@ -13,5 +13,6 @@ env.Append(
                 "-Wl,-u,_printf_float",
                 "--specs=nano.specs",
                 "--specs=nosys.specs"
-            ]
-           )
+            ])
+
+env.Append( CXXFLAGS=[ "-Wno-register" ] )

--- a/src/dcdc.cpp
+++ b/src/dcdc.cpp
@@ -47,41 +47,64 @@ void dcdc_init(Dcdc *dcdc)
 }
 
 // returns if output power should be increased (1), decreased (-1) or switched off (0)
-int _dcdc_output_control(Dcdc *dcdc, DcBus *out, DcBus *in)
+/**
+ * @param dcdc_dir 1 =>  current flows from ls to hs through the dcdc, -1 opposite
+ */ 
+int _dcdc_output_control(Dcdc *dcdc, DcBus *out, DcBus *in, const int dcdc_dir)
 {
-    float dcdc_power_new = fabs(dcdc->ls_voltage * dcdc->ls_current); // voltage always positive, current is negative in boost mode
+    float dcdc_power_new = dcdc->ls_voltage * dcdc->ls_current * dcdc_dir;
     static int pwm_delta = 1;
+
+    static uint32_t low_dcdc_power_count = 0;
+
+    // less than 1W dcdc power
+    bool dcdc_power_low = dcdc_power_new < 1.0;
+
+    // count how long low power condition remains
+    // reset counter if no lower power condition
+    low_dcdc_power_count  = dcdc_power_low ? low_dcdc_power_count + 1 : 0;
+
+    int retval = 0;
 
     //printf("P: %.2f, P_prev: %.2f, v_in: %.2f, v_out: %.2f, i_in: %.2f, i_out: %.2f, i_max: %.2f, PWM: %.1f, chg_en: %d\n",
     //     dcdc_power_new, dcdc->power, in->voltage, out->voltage, in->current, out->current,
     //     out->chg_current_max, half_bridge_get_duty_cycle() * 100.0, out->chg_allowed);
-
-    if (out->chg_allowed == false || in->dis_allowed == false
-        || (in->voltage < in->dis_voltage_stop && out->current < 0.1))
+    if  (
+            (out->chg_allowed == false && out->dis_allowed == false)        // we are not supposed to transfer any energy into the outputs
+            || low_dcdc_power_count > 100                                 // the transfered energy drops below a threshold for more than 10s, we make a small averaging here
+            || in->dis_allowed == false                                     // we are not allowed to take energy from the input 
+            // || (in->voltage < in->dis_voltage_stop && out->current < 0.1)   // input voltage is too low and we have no output consumption (battery or grid)
+        ) 
     {
-        return 0;
+#if 0        
+        printf("P: %.2f, P_prev: %.2f, i_v: %.2f, o_v: %.2f, i_cur: %.2f, o_cur: %.2f, o_chg_cur_max: %.2f, PWM: %.1f, o_chg_en: %d o_dis_en: %d, i_dis_en: %d, i_v_dis_volt_stop: %.2f, dc_ls_cur: %.2f\n",
+         dcdc_power_new, dcdc->power, in->voltage, out->voltage, in->current, out->current,
+         out->chg_current_max, half_bridge_get_duty_cycle() * 100.0, out->chg_allowed, out->dis_allowed, in->dis_allowed, in->dis_voltage_stop, dcdc->ls_current);
+#endif        
+        low_dcdc_power_count = 0; // reset low dcdc current "timer" 
+        retval = 0;
     }
     else if (out->voltage > (out->chg_voltage_target - out->chg_droop_res * out->current)                     // output voltage above target
         || (in->voltage < (in->dis_voltage_start - in->dis_droop_res * in->current) && out->current > 0.1))     // input voltage below limit
     {
         dcdc->state = DCDC_STATE_CV;
-        return -1;  // decrease output power
+        retval = -1;  // decrease output power
     }
-    else if (out->current > out->chg_current_max         // output current limit exceeded
-        || in->current < in->dis_current_max)             // input current (negative signs) limit exceeded
+    else if (out->current > out->chg_current_max         // output charge current limit exceeded
+        || in->current < in->dis_current_max)            // input current (negative signs) limit exceeded
     {
         dcdc->state = DCDC_STATE_CC;
-        return -1;  // decrease output power
+        retval = -1;  // decrease output power
     }
     else if (fabs(dcdc->ls_current) > dcdc->ls_current_max          // current above hardware maximum
         || dcdc->temp_mosfets > 80)                                 // temperature limits exceeded
     {
         dcdc->state = DCDC_STATE_DERATING;
-        return -1;  // decrease output power
+        retval = -1;  // decrease output power
     }
-    else if (out->current < 0.1 && out->voltage < out->dis_voltage_start)  // no load condition (e.g. start-up of nanogrid) --> raise voltage
+    else if (dcdc_power_low == true && out->voltage < out->dis_voltage_start)  // no load condition (e.g. start-up of nanogrid) --> raise voltage
     {
-        return 1;   // increase output power
+        retval = 1;   // increase output power
     }
     else {
         // start MPPT
@@ -89,9 +112,11 @@ int _dcdc_output_control(Dcdc *dcdc, DcBus *out, DcBus *in)
         if (dcdc->power > dcdc_power_new) {
             pwm_delta = -pwm_delta;
         }
-        dcdc->power = dcdc_power_new;
-        return pwm_delta;
+        retval = pwm_delta;
     }
+    // store the power BEFORE the executing the current change
+    dcdc->power = dcdc_power_new;
+    return retval;
 }
 
 bool _dcdc_check_start_conditions(Dcdc *dcdc, DcBus *out, DcBus *in)
@@ -110,14 +135,19 @@ void dcdc_control(Dcdc *dcdc, DcBus *hs, DcBus *ls)
 {
     if (half_bridge_enabled()) {
         int step;
-        if (dcdc->ls_current > 0.1) {    // buck mode
+
+        if (dcdc->mode == MODE_MPPT_BUCK  || dcdc->ls_current > 0.1 ) {    
+            // always in buck mode or when boost or nano grid are receiving energy from high side enegry producer
+            // ( grid [nanogrid] or battery [boost] )
+            // for low side energy consumers (battery and/or load).
+
             //printf("-");
-            step = _dcdc_output_control(dcdc, ls, hs);
+            step = _dcdc_output_control(dcdc, ls, hs, 1);
             half_bridge_duty_cycle_step(step);
         }
         else {
             //printf("+");
-            step = _dcdc_output_control(dcdc, hs, ls);
+            step = _dcdc_output_control(dcdc, hs, ls, -1);
             half_bridge_duty_cycle_step(-step);
         }
 


### PR DESCRIPTION
The dcdc_control now better controls which mode (boost vs. buck) is being
used when: If configured in Buck mode, boost mode is never used.

The _dcdc_control function now "knows" if it is in boost or buck mode (dcdc_dir)

The no load condition now uses the dcdc transfer power as measure, not the out current
which is not reflecting the "no dcdc load" condition correctly if a load is connected

See #48