### PR TITLE
Fix build issue with mbed 5.13

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -46,7 +46,7 @@ build_flags =
     -D MBED_BUILD_PROFILE_RELEASE
 #    -D MBED_BUILD_PROFILE_DEBUG
 
-build_unflags = -std=gnu++98
+build_unflags = -std=gnu++98  -std=gnu++14
 extra_scripts =
     linker_flags_newlib-nano.py
     generate_version_file.py


### PR DESCRIPTION
In order to use templates in an easy way we were switching to c++ 17 standard by adding -std=gnu++17 to the compiler settings. Unfortunately we have additionally to tell platformio to "disable" the standard setting it wants to use, which was -std=gnu++98 for mbed 5.3.0 
But for mbed 5.13 it is -std=gnu++14 so it is not removed platformio and takes precedence over -std=gnu++17 . Argh.
Now we add -std=gnu++14 in addition to -std=gnu++98 to build_unflags to make platformio do what makes sense.