### PR TITLE
Small fix for building unit test on Windows

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -104,9 +104,10 @@ build_flags = ${env.build_flags}
 platform = native
 framework =
 build_flags =
-    -std=gnu++11
+    -std=gnu++17
     -D LITTLE_ENDIAN
     -D UNIT_TEST
+    -D __STDC_FORMAT_MACROS
 # include src directory (otherwise unit-tests will only include lib directory)
 test_build_project_src = true
 lib_ignore = USB, mbed-USBDevice, mbed-mbedtls, USBSerial, ESP32, Adafruit_GFX, SX1276GenericLib


### PR DESCRIPTION
Was necessary to add -D __STDC_FORMAT_MACROS for MinGW gcc 8.1.0