### PR TITLE
Fix rounding issue

### DIFF
--- a/src/half_bridge_tim.cpp
+++ b/src/half_bridge_tim.cpp
@@ -297,10 +297,10 @@ void half_bridge_set_duty_cycle(float duty)
 {
     _half_bridge_set_duty_cycle(_pwm_resolution * duty);
 }
-
+#include <stdio.h>
 void half_bridge_duty_cycle_step(int delta)
 {
-    half_bridge_set_duty_cycle(((float)(PWM_TIM_HW::get_ccr() + delta))/_pwm_resolution);
+    _half_bridge_set_duty_cycle(PWM_TIM_HW::get_ccr() + delta);
 }
 
 float half_bridge_get_duty_cycle()


### PR DESCRIPTION
In some cases the old code would cause a +1/-1 step not actually changing the PWM due to rounding issues.
New code directly changes the integer value and thus avoids this issue.

BTW: This issue was found by the unit tests which passed on travis but not on my dev machine.  