### PR TITLE
Bootloader support in Charge Controller firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ If used together with Visual Studio Code and PlatformIO, starting firmware devel
 
 5. Press the upload button at the bottom left corner in VS Code.
 
+## Bootloader Support
+
+The custom linker script file need to be updated before generating the application firmware binary. The STM32L073XZ.ld.link_script.ld file is located in the root project directory. For each application, the flash start address and the maximum code size need to be updated in this file. Currently, the locations 0x08001000 and 0x08018000 are used for applications 1 & 2 respectively.
+
 ### Troubleshooting
 
 #### Errors with STM32L072 MCU using OpenOCD

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ The software is configurable to support different charge controller PCBs with ei
 - [Libre Solar MPPT 12V 10A with USB (v0.2 and v0.4)](https://github.com/LibreSolar/MPPT-1210-HUS)
 - [Libre Solar PWM 12/24V 20A](https://github.com/LibreSolar/PWM-2420-LUS)
 
+## Bootloader Support
+
+The custom linker script file need to be updated before generating the application firmware binary. The STM32L073XZ.ld.link_script.ld file is located in the root project directory. For each application, the flash start address and the maximum code size need to be updated in this file. Currently, the locations 0x08001000 and 0x08018000 are used for applications 1 & 2 respectively.
+
 ## Building and flashing the firmware
 
 This firmware is developed using the [ARM mbed OS](https://developer.mbed.org/) embedded framework which has easy-to-understand C++ syntax (similar to Arduino) and thus enhances community based software development.
@@ -27,10 +31,6 @@ If used together with Visual Studio Code and PlatformIO, starting firmware devel
 4. Connect the board via a programmer. See the Libre Solar website for [further project-agnostic instructions](http://libre.solar/docs/flashing).
 
 5. Press the upload button at the bottom left corner in VS Code.
-
-## Bootloader Support
-
-The custom linker script file need to be updated before generating the application firmware binary. The STM32L073XZ.ld.link_script.ld file is located in the root project directory. For each application, the flash start address and the maximum code size need to be updated in this file. Currently, the locations 0x08001000 and 0x08018000 are used for applications 1 & 2 respectively.
 
 ### Troubleshooting
 

--- a/STM32L073XZ.ld.link_script.ld
+++ b/STM32L073XZ.ld.link_script.ld
@@ -1,0 +1,92 @@
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x08018000, LENGTH = 94k
+  RAM (rwx) : ORIGIN = 0x200000C0, LENGTH = 20K - 0xC0
+}
+ENTRY(Reset_Handler)
+SECTIONS
+{
+    .text :
+    {
+        KEEP(*(.isr_vector))
+        *(.text*)
+        KEEP(*(.init))
+        KEEP(*(.fini))
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+        *(.rodata*)
+        KEEP(*(.eh_frame*))
+    } > FLASH
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > FLASH
+    __exidx_end = .;
+    __etext = .;
+    _sidata = .;
+    .data : AT (__etext)
+    {
+        __data_start__ = .;
+        _sdata = .;
+        *(vtable)
+        *(.data*)
+        . = ALIGN(8);
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+        . = ALIGN(8);
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+        . = ALIGN(8);
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+        KEEP(*(.jcr*))
+        . = ALIGN(8);
+        __data_end__ = .;
+        _edata = .;
+    } > RAM
+    .bss :
+    {
+        . = ALIGN(8);
+        __bss_start__ = .;
+        _sbss = .;
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(8);
+        __bss_end__ = .;
+        _ebss = .;
+    } > RAM
+    .heap (COPY):
+    {
+        __end__ = .;
+        end = __end__;
+        *(.heap*)
+        __HeapLimit = .;
+    } > RAM
+    .stack_dummy (COPY):
+    {
+        *(.stack*)
+    } > RAM
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    _estack = __StackTop;
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,6 +16,7 @@ default_envs =
 #    mppt-1210-hus-v0.7
 #    pwm-2420-lus-v0.2
 #    pwm-2420-lus-v0.3
+    pwm-2420-lus-v0.3-bl
 #    unit-test-native
 
 [env]
@@ -100,6 +101,13 @@ build_flags = ${env.build_flags}
 board = nucleo_l073rz
 build_flags = ${env.build_flags}
     -D PWM_2420_LUS_0V3
+
+[env:pwm-2420-lus-v0.3-bl]
+board = nucleo_l073rz
+build_flags = ${env.build_flags}
+    -D PWM_2420_LUS_0V3
+    -D BOOTLOADER_ENABLED
+    -Wl,-T'"$PROJECT_DIR\STM32L073XZ.ld.link_script.ld"',-v
 
 [env:unit-test-native]
 platform = native

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ default_envs =
 #    mppt-1210-hus-v0.7
 #    pwm-2420-lus-v0.2
 #    pwm-2420-lus-v0.3
-    pwm-2420-lus-v0.3-bl
+#    pwm-2420-lus-v0.3-bl
 #    unit-test-native
 
 [env]

--- a/src/bl_support.cpp
+++ b/src/bl_support.cpp
@@ -23,11 +23,10 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  *
  */
+#ifdef BOOTLOADER_ENABLED
 
 #include "bl_support.h"
-#ifdef BOOTLOADER_ENABLED
 #include "stm32l0xx.h"
-#endif
 #include "debug.h"
 
 /**
@@ -140,8 +139,6 @@ void write_status_reg(BootloaderStatus& status)
 // Called from main
 void check_bootloader(void)
 {
-    #ifdef BOOTLOADER_ENABLED
-
     //print_info("App1...\r\n");
 
     // Read the bootloader status from the flash memory location
@@ -153,5 +150,6 @@ void check_bootloader(void)
         write_status_reg(status_reg); // Write the status to flash
         //print_info("Switched to stable app...\r\n");
     }
-    #endif
 }
+
+#endif /*BOOTLOADER_ENABLED*/

--- a/src/bl_support.cpp
+++ b/src/bl_support.cpp
@@ -25,10 +25,10 @@
  */
 
 #include "bl_support.h"
+#ifdef BOOTLOADER_ENABLED
 #include "stm32l0xx.h"
-#include "thingset_serial.h"
-
-extern Serial serial;
+#endif
+#include "debug.h"
 
 /**
  * Unlock the FLASH control register access and the program memory access.
@@ -142,7 +142,7 @@ void check_bootloader(void)
 {
     #ifdef BOOTLOADER_ENABLED
 
-    //printf("App2...\r\n");
+    //print_info("App1...\r\n");
 
     // Read the bootloader status from the flash memory location
     BootloaderStatus status_reg = *((BootloaderStatus *)BOOTLOADER_STATUS_STRUCT_ADDR);
@@ -151,7 +151,7 @@ void check_bootloader(void)
     if (status_reg.status == BootloaderState::ATTEMPT_NEW_APP) {
         status_reg.status = BootloaderState::STABLE_APP;
         write_status_reg(status_reg); // Write the status to flash
-        //printf("Switched to stable app...\r\n");
+        //print_info("Switched to stable app...\r\n");
     }
     #endif
 }

--- a/src/bl_support.cpp
+++ b/src/bl_support.cpp
@@ -1,0 +1,157 @@
+/*
+ * Scene Connect Bootloader
+ * Copyright (C) 2019 Scene Connect 
+ * https://www.scene.community/
+ *
+ * This code is developed based on the Okra Bootloader from Okra Solar.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include "bl_support.h"
+#include "stm32l0xx.h"
+#include "thingset_serial.h"
+
+extern Serial serial;
+
+/**
+ * Unlock the FLASH control register access and the program memory access.
+ */
+void flash_unlock(void)
+{
+    if (HAL_IS_BIT_SET(FLASH->PECR, FLASH_PECR_PRGLOCK)) {
+        /* Unlocking FLASH_PECR register access*/
+        if (HAL_IS_BIT_SET(FLASH->PECR, FLASH_PECR_PELOCK)) {
+            WRITE_REG(FLASH->PEKEYR, FLASH_PEKEY1);
+            WRITE_REG(FLASH->PEKEYR, FLASH_PEKEY2);
+        }        
+        /* Unlocking the program memory access */
+        WRITE_REG(FLASH->PRGKEYR, FLASH_PRGKEY1);
+        WRITE_REG(FLASH->PRGKEYR, FLASH_PRGKEY2);  
+    }
+    else {
+        // Error handler
+    }
+}
+
+/**
+ * Program a word at a specified address in the flash memory.
+ * (1) Perform the data write (32-bit word) at the desired address
+ * (2) Wait until the BSY bit is reset in the FLASH_SR register
+ * (3) Check the EOP flag in the FLASH_SR register
+ * (4) clear it by software by writing it at 1 
+ */
+void flash_program(uint32_t address, uint32_t data)
+{
+    /* Program word (32-bit) at a specified address.*/
+    *(__IO uint32_t *)address = data;
+
+    while ((FLASH->SR & FLASH_SR_BSY) != 0) { /* (2) */
+        /* For robust implementation, add here time-out management */
+    }
+    if ((FLASH->SR & FLASH_SR_EOP) != 0) { /* (3) */
+        FLASH->SR = FLASH_SR_EOP; /* (4) */
+    }
+    else {
+        /* Manage the error cases */
+    }
+}
+
+/**
+ * Function to write the bootloader status to the flash address 'BOOTLOADER_STATUS_STRUCT_ADDR'.
+ * @param status: The struct containing the bootloader status information.
+ */
+void write_status_reg(BootloaderStatus& status)
+{
+    // Make sure the status reg is halfword aligned
+    // Check if this is really required.
+    static_assert(sizeof(status) % 2 == 0);
+    
+    // Unlock the FLASH_PECR register access.
+    // Then unlock the program memory access.
+    flash_unlock();     
+
+    /* 
+    * Erase a page in the Flash at BOOTLOADER_STATUS_STRUCT_ADDR - For STM32L073RZ
+    * (1) Set the ERASE and PROG bits in the FLASH_PECR register to enable page erasing 
+    * (2) Write a 32-bit word value in an address of the selected page to start the erase sequence 
+    * (3) Wait until the BSY bit is reset in the FLASH_SR register 
+    * (4) Check the EOP flag in the FLASH_SR register 
+    * (5) Clear EOP flag by software by writing EOP at 1 
+    * (6) Reset the ERASE and PROG bits in the FLASH_PECR register to disable the page erase 
+    * Program and erase control register (FLASH_PECR) - This register can only be written after a 
+    * good write sequence done in FLASH_PEKEYR, resetting the PELOCK bit.
+    */
+    FLASH->PECR |= FLASH_PECR_ERASE | FLASH_PECR_PROG;
+
+    *(__IO uint32_t *)BOOTLOADER_STATUS_STRUCT_ADDR = (uint32_t)0;
+  
+    while ((FLASH->SR & FLASH_SR_BSY) != 0) {
+        /* For robust implementation, add here time-out management */
+    }
+
+    if ((FLASH->SR & FLASH_SR_EOP) != 0) { 
+        FLASH->SR = FLASH_SR_EOP;
+    }
+    else {
+        /* Manage the error cases */
+    }
+    FLASH->PECR &= ~(FLASH_PECR_ERASE | FLASH_PECR_PROG);
+
+    /*
+    * Write status struct to the flash
+    * (1) Set the PROG and FPRG bits in the FLASH_PECR register to enable a half page programming
+    * (2) Perform the data write (half-word) at the desired address
+    * (3) Wait until the BSY bit is reset in the FLASH_SR register
+    * (4) Check the EOP flag in the FLASH_SR register
+    * (5) clear it by software by writing it at 1
+    * (6) Reset the PROG and FPRG bits to disable programming
+    */
+    uint32_t *data = (uint32_t *)&status;
+    uint32_t address = BOOTLOADER_STATUS_STRUCT_ADDR;    
+
+    for (unsigned int i = 0; i < sizeof(status) / sizeof(uint32_t); i++) {
+        flash_program(address, *data); 
+        data++;
+        address += 4;
+    }  
+
+    // Locking FLASH_PECR register again
+    // Set the PRGLOCK Bit to lock the FLASH Registers access 
+    SET_BIT(FLASH->PECR, FLASH_PECR_PRGLOCK);    
+}
+
+// Called from main
+void check_bootloader(void)
+{
+    #ifdef BOOTLOADER_ENABLED
+
+    //printf("App2...\r\n");
+
+    // Read the bootloader status from the flash memory location
+    BootloaderStatus status_reg = *((BootloaderStatus *)BOOTLOADER_STATUS_STRUCT_ADDR);
+
+    // If the Bootloader Status is ATTEMPT_NEW_APP, change it to STABLE_APP
+    if (status_reg.status == BootloaderState::ATTEMPT_NEW_APP) {
+        status_reg.status = BootloaderState::STABLE_APP;
+        write_status_reg(status_reg); // Write the status to flash
+        //printf("Switched to stable app...\r\n");
+    }
+    #endif
+}

--- a/src/bl_support.h
+++ b/src/bl_support.h
@@ -1,0 +1,103 @@
+/*
+ * Scene Connect Bootloader
+ * Copyright (C) 2019 Scene Connect 
+ * https://www.scene.community/
+ *
+ * This code is developed based on the Okra Bootloader from Okra Solar.
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+#ifndef BOOTLOADER_H
+#define BOOTLOADER_H
+
+#pragma once
+
+#include <cstdint>
+
+#include "config.h"
+
+/** Length of the bootloader name string (including \0 termination) */
+const uint8_t BOOTLADER_NAME_LENGTH = 18;
+
+/**
+ * Flash address for the bootloader status structure.
+ * This address must be aligned to a flash page. Each time a new application
+ * is detected by the bootloader (BootloaderState::newApp),
+ * the full page is erased, and the updated struct is written to the address 
+ */
+const uint32_t BOOTLOADER_STATUS_STRUCT_ADDR = 0x0802FF80; // The last flash page
+
+/**
+ * Bootloader state enumeration. This state needs to be set to "newApp"
+ * by the application after an update, and to "stableApp" after the
+ * first successful boot 
+ */
+enum BootloaderState {
+    NO_STATE = 0,     // State not properly initialized
+    NEW_APP,          // Set By App after download of the binary
+    ATTEMPT_NEW_APP,  // Set by Bootloader when first booting the new binary
+    STABLE_APP,       // Set by App after sucessful boot of the new app
+};
+
+/** 
+ * Bootloader status struct. This struct's status field should be updated
+ * in flash by the app after first boot (stableApp) or after an update of the
+ * other firmware binary (newApp) 
+ */
+struct BootloaderStatus {
+    char bootloader_name[BOOTLADER_NAME_LENGTH];
+    uint32_t bootloader_version;
+    uint32_t status;   // Update this field and write to flash in your app!
+    uint32_t live_app_select;
+    uint32_t retry_count;
+};
+
+/**
+ * Write the bootloader status to the flash address 'BOOTLOADER_STATUS_STRUCT_ADDR'.
+ * 
+ * @param status: The struct containing the bootloader status information.
+ */
+void write_status_reg(BootloaderStatus &status);
+
+/**
+ * Unlock the FLASH control register access and the program memory access.
+ */
+void flash_unlock(void);
+
+/**
+ * Program a word at a specified address in the flash memory.
+ * (1) Perform the data write (32-bit word) at the desired address
+ * (2) Wait until the BSY bit is reset in the FLASH_SR register
+ * (3) Check the EOP flag in the FLASH_SR register
+ * (4) clear it by software by writing it at 1 
+ * 
+ * @param address The flash address to write to.
+ * @param data The data to write to the flash.
+ */
+void flash_program(uint32_t address, uint32_t data);
+
+
+/**
+ *  Called from main. This implements the bootloader status update from the application side.
+ */
+void check_bootloader(void);
+
+
+
+#endif /*BOOTLOADER_H*/

--- a/src/bl_support.h
+++ b/src/bl_support.h
@@ -28,6 +28,8 @@
 
 #pragma once
 
+#ifdef BOOTLOADER_ENABLED
+
 #include <cstdint>
 
 #include "config.h"
@@ -98,6 +100,6 @@ void flash_program(uint32_t address, uint32_t data);
  */
 void check_bootloader(void);
 
-
+#endif /*BOOTLOADER_ENABLED*/
 
 #endif /*BOOTLOADER_H*/

--- a/src/bl_support.h
+++ b/src/bl_support.h
@@ -49,10 +49,10 @@ const uint32_t BOOTLOADER_STATUS_STRUCT_ADDR = 0x0802FF80; // The last flash pag
  * first successful boot 
  */
 enum BootloaderState {
-    NO_STATE = 0,     // State not properly initialized
-    NEW_APP,          // Set By App after download of the binary
-    ATTEMPT_NEW_APP,  // Set by Bootloader when first booting the new binary
-    STABLE_APP,       // Set by App after sucessful boot of the new app
+    NO_STATE = 0,     ///< State not properly initialized
+    NEW_APP,          ///< Set By App after download of the binary
+    ATTEMPT_NEW_APP,  ///< Set by Bootloader when first booting the new binary
+    STABLE_APP,       ///< Set by App after sucessful boot of the new app
 };
 
 /** 
@@ -63,8 +63,8 @@ enum BootloaderState {
 struct BootloaderStatus {
     char bootloader_name[BOOTLADER_NAME_LENGTH];
     uint32_t bootloader_version;
-    uint32_t status;   // Update this field and write to flash in your app!
-    uint32_t live_app_select;
+    uint32_t status;   ///< Update this field and write to flash in your app!
+    uint32_t live_app_select; 
     uint32_t retry_count;
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,6 +41,7 @@
 #include "data_objects.h"       // for access to internal data via ThingSet
 #include "thingset_serial.h"    // UART or USB serial communication
 #include "thingset_can.h"       // CAN bus communication
+#include "bl_support.h"         // Bootloader support from the application side
 
 PowerPort lv_terminal;          // low voltage terminal (battery for typical MPPT)
 
@@ -86,6 +87,10 @@ Serial serial(PIN_SWD_TX, PIN_SWD_RX, "serial", 115200);
  */
 int main()
 {
+    #ifdef BOOTLOADER_ENABLED
+    check_bootloader(); // Update the bootloader status in flash to a stable state.
+    #endif
+
     leds_init();
 
     battery_conf_init(&bat_conf, BATTERY_TYPE, BATTERY_NUM_CELLS, BATTERY_CAPACITY);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -41,7 +41,10 @@
 #include "data_objects.h"       // for access to internal data via ThingSet
 #include "thingset_serial.h"    // UART or USB serial communication
 #include "thingset_can.h"       // CAN bus communication
+
+#ifdef BOOTLOADER_ENABLED
 #include "bl_support.h"         // Bootloader support from the application side
+#endif
 
 PowerPort lv_terminal;          // low voltage terminal (battery for typical MPPT)
 


### PR DESCRIPTION
What does this PR do?
A custom linker script (.ld) is added to the root project folder. 
platformio.ini file updated to add the new env: pwm-2420-lus-v0.3-bl and build_flags.
Readme file is updated accordingly. New functions added to perform flash write operations to store the bootloader status.

What are the relevant tickets?

Where should the reviewer start?

How should this be manually tested?
Start address for each Application in the flash need to be is modified in .ld file. Then flash the code to the specific flash location, say using STLink Utility.

Any background context you want to provide?
Screenshots (if appropriate)