### PR TITLE
Load protection improvements

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -22,7 +22,7 @@ default_envs =
 [env]
 
 # select specific stm32 version, as automatic updates of mbed could break compatibility
-platform = ststm32@~5.6.0
+platform = ststm32@~5.3.0
 #platform = https://github.com/platformio/platform-ststm32.git
 
 framework = mbed

--- a/src/adc_dma.cpp
+++ b/src/adc_dma.cpp
@@ -175,6 +175,15 @@ void update_measurements()
     uint16_t adcval = (adc_filtered[ADC_POS_TEMP_MCU] >> (4 + ADC_FILTER_CONST)) * vcc / VREFINT_VALUE;
     internal_temp = (TSENSE_CAL2_VALUE - TSENSE_CAL1_VALUE) /
         (TSENSE_CAL2 - TSENSE_CAL1) * (adcval - TSENSE_CAL1) + TSENSE_CAL1_VALUE;
+
+    if (internal_temp > 80) {
+        log_data.error_flags |= 1U << ERR_INT_OVERTEMP;
+    }
+    else if (internal_temp < 70 && (log_data.error_flags & (1U << ERR_INT_OVERTEMP))) {
+        // remove error flag with hysteresis of 10°C
+        log_data.error_flags &= ~(1U << ERR_INT_OVERTEMP);
+    }
+    // else: keep previous setting
 }
 
 #ifndef UNIT_TEST

--- a/src/adc_dma.h
+++ b/src/adc_dma.h
@@ -34,10 +34,6 @@
  */
 void calibrate_current_sensors();
 
-/** Detects if external temperature sensor is attached, otherwise takes internal sensor
- */
-void detect_battery_temperature(Charger *bat, float bat_temp);
-
 /** Updates structures with data read from ADC
  */
 void update_measurements();

--- a/src/data_objects.cpp
+++ b/src/data_objects.cpp
@@ -36,7 +36,7 @@ const char* const firmware_commit = COMMIT_HASH;
 uint32_t device_id = DEVICE_ID;      // from config.h
 
 extern uint32_t timestamp;
-float mcu_temp;
+float internal_temp;
 
 /** Data Objects
  *
@@ -131,7 +131,7 @@ const data_object_t data_objects[] = {
     {0x73, TS_OUTPUT, TS_READ_ALL, TS_T_FLOAT32, 2, (void*) &(load_terminal.current),                   "Load_A"},
     {0x74, TS_OUTPUT, TS_READ_ALL, TS_T_FLOAT32, 1, (void*) &(charger.bat_temperature),                 "Bat_degC"},
     {0x75, TS_OUTPUT, TS_READ_ALL, TS_T_BOOL,    1, (void*) &(charger.ext_temp_sensor),                 "BatTempExt"},
-    {0x76, TS_OUTPUT, TS_READ_ALL, TS_T_FLOAT32, 1, (void*) &(mcu_temp),                                "MCU_degC"},
+    {0x76, TS_OUTPUT, TS_READ_ALL, TS_T_FLOAT32, 1, (void*) &(internal_temp),                           "Int_degC"},
 #if defined(PIN_ADC_TEMP_FETS) && FEATURE_DCDC_CONVERTER
     {0x77, TS_OUTPUT, TS_READ_ALL, TS_T_FLOAT32, 1, (void*) &(dcdc.temp_mosfets),                       "Mosfet_degC"},
 #endif

--- a/src/leds.cpp
+++ b/src/leds.cpp
@@ -264,4 +264,9 @@ void leds_update_soc(int soc, bool load_off_low_soc)
 #endif
 }
 
+#else
+
+// dummy functions
+void leds_flicker(int led, int timeout) {}
+
 #endif /* UNIT_TEST */

--- a/src/load.cpp
+++ b/src/load.cpp
@@ -349,7 +349,8 @@ void LoadOutput::control()
     junction_temperature = junction_temperature + (
             internal_temp - junction_temperature +
             port->current * port->current /
-            (LOAD_CURRENT_MAX * LOAD_CURRENT_MAX) * (MOSFET_MAX_JUNCTION_TEMP - 25)
+            (LOAD_CURRENT_MAX * LOAD_CURRENT_MAX) *
+            (MOSFET_MAX_JUNCTION_TEMP - INTERNAL_MAX_REFERENCE_TEMP)
         ) / (MOSFET_THERMAL_TIME_CONSTANT * CONTROL_FREQUENCY);
 
     if (junction_temperature > MOSFET_MAX_JUNCTION_TEMP

--- a/src/load.cpp
+++ b/src/load.cpp
@@ -295,8 +295,10 @@ void LoadOutput::state_machine()
             }
             break;
         case LOAD_STATE_OFF_LOW_SOC:
-            // wait configured time
-            if (time(NULL) - lvd_timestamp > lvd_recovery_delay) {
+            // wait at least configured time
+            if (time(NULL) - lvd_timestamp > lvd_recovery_delay &&
+                !(log_data.error_flags & (1 << ERR_BAT_UNDERVOLTAGE)))
+            {
                 state = LOAD_STATE_DISABLED; // switch to normal mode again
             }
             break;

--- a/src/load.cpp
+++ b/src/load.cpp
@@ -25,7 +25,7 @@
 volatile bool short_circuit = false;
 
 extern LogData log_data;
-extern float mcu_temp;
+extern float internal_temp;
 
 #ifndef UNIT_TEST
 
@@ -347,7 +347,7 @@ void LoadOutput::control()
 
     // junction temperature calculation model for overcurrent detection
     junction_temperature = junction_temperature + (
-            mcu_temp - junction_temperature +
+            internal_temp - junction_temperature +
             port->current * port->current /
             (LOAD_CURRENT_MAX * LOAD_CURRENT_MAX) * (MOSFET_MAX_JUNCTION_TEMP - 25)
         ) / (MOSFET_THERMAL_TIME_CONSTANT * CONTROL_FREQUENCY);

--- a/src/load.h
+++ b/src/load.h
@@ -40,7 +40,7 @@ enum LoadState {
     LOAD_STATE_OFF_OVERCURRENT,     ///< Off to protect charge controller (overrules target setting)
     LOAD_STATE_OFF_OVERVOLTAGE,     ///< Off to protect loads (overrules target setting)
     LOAD_STATE_OFF_SHORT_CIRCUIT,   ///< Off to protect charge controller (overrules target setting)
-    LOAD_STATE_OFF_BAT_TEMP         ///< Off because of battery over/under-temperature
+    LOAD_STATE_OFF_TEMPERATURE      ///< Off because of battery or charge controller temperature
 };
 
 /** Load output type

--- a/src/load.h
+++ b/src/load.h
@@ -86,6 +86,8 @@ public:
     PowerPort *port;            ///< Pointer to DC bus containting actual voltage and current
                                 ///< measurement of (external) load output terminal
 
+    float voltage_prev;         ///< voltage from previous call of control function
+
     time_t overcurrent_timestamp;       ///< Time when last overcurrent event occured
     int overcurrent_recovery_delay;     ///< Seconds before we attempt to re-enable the load
                                         ///< after an overcurrent event

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -23,7 +23,7 @@
 #include <math.h>       // for fabs function
 #include <stdio.h>
 
-extern float mcu_temp;
+extern float internal_temp;
 
 //----------------------------------------------------------------------------
 // must be called exactly once per second, otherwise energy calculation gets wrong
@@ -112,7 +112,7 @@ void log_update_min_max_values(LogData *log_data)
         log_data->bat_temp_max = charger.bat_temperature;
     }
 
-    if (mcu_temp > log_data->int_temp_max) {
-        log_data->int_temp_max = mcu_temp;
+    if (internal_temp > log_data->int_temp_max) {
+        log_data->int_temp_max = internal_temp;
     }
 }

--- a/src/log.h
+++ b/src/log.h
@@ -39,7 +39,12 @@ enum ErrorFlag {
     ERR_BAT_DIS_OVERTEMP,
     ERR_BAT_DIS_UNDERTEMP,
     ERR_BAT_CHG_OVERTEMP,
-    ERR_BAT_CHG_UNDERTEMP
+    ERR_BAT_CHG_UNDERTEMP,
+    ERR_LOAD_OVERVOLTAGE,           ///< To high voltage for load so that it was switched off
+    ERR_LOAD_SHORT_CIRCUIT,         ///< Short circuit detected by load port
+    ERR_LOAD_OVERCURRENT,           ///< Long-term overcurrent of charge controller
+    ERR_LOAD_VOLTAGE_DIP            ///< Overcurrent identified via voltage dip (may be because of
+                                    ///< too small battery)
 };
 
 /** Log Data

--- a/src/log.h
+++ b/src/log.h
@@ -43,8 +43,9 @@ enum ErrorFlag {
     ERR_LOAD_OVERVOLTAGE,           ///< To high voltage for load so that it was switched off
     ERR_LOAD_SHORT_CIRCUIT,         ///< Short circuit detected by load port
     ERR_LOAD_OVERCURRENT,           ///< Long-term overcurrent of charge controller
-    ERR_LOAD_VOLTAGE_DIP            ///< Overcurrent identified via voltage dip (may be because of
+    ERR_LOAD_VOLTAGE_DIP,           ///< Overcurrent identified via voltage dip (may be because of
                                     ///< too small battery)
+    ERR_INT_OVERTEMP                ///< Charge controller internal temperature too high
 };
 
 /** Log Data

--- a/src/pcb.h
+++ b/src/pcb.h
@@ -41,6 +41,14 @@
  */
 #define MOSFET_MAX_JUNCTION_TEMP    120
 
+/** Internal reference temperature at full load (°C)
+ *
+ * This value is used for model-based control of overcurrent protection. It represents
+ * the steady-state internal temperature for max. continuous current at ambient
+ * temperature of 25°C.
+ */
+#define INTERNAL_MAX_REFERENCE_TEMP 50
+
 /** Thermal time constant junction to ambient (s)
  *
  * This value is used for model-based control of overcurrent protection. It does not reflect

--- a/src/pcbs/mppt_1210_hus_0v7.h
+++ b/src/pcbs/mppt_1210_hus_0v7.h
@@ -60,6 +60,8 @@
 
 #define PIN_REF_I_DCDC  PA_4
 
+// Internal NTC temperature currently ignored by firmware as it is similar to MCU temperature and
+// does not reflect external battery temperature. Feature will be removed in future HW revisions.
 #define PIN_TEMP_INT_PD PA_8
 
 enum pin_state_t { PIN_HIGH, PIN_LOW, PIN_FLOAT };

--- a/src/pcbs/pwm_2420_lus.h
+++ b/src/pcbs/pwm_2420_lus.h
@@ -62,6 +62,8 @@
 
 #define PIN_REF_I_DCDC  PA_4
 
+// Internal NTC temperature currently ignored by firmware as it is similar to MCU temperature and
+// does not reflect external battery temperature. Feature will be removed in future HW revisions.
 #define PIN_TEMP_INT_PD PA_8
 
 enum pin_state_t { PIN_HIGH, PIN_LOW, PIN_FLOAT };

--- a/test/adc_dma_stub.h
+++ b/test/adc_dma_stub.h
@@ -24,7 +24,6 @@ typedef struct {
     float dcdc_current;
     float load_current;
     float bat_temperature;
-    float mcu_temperature;
     float internal_temperature;
 } adc_values_t;
 

--- a/test/tests_adc.cpp
+++ b/test/tests_adc.cpp
@@ -50,7 +50,6 @@ void adc_tests()
     adcval.dcdc_current = 3;
     adcval.internal_temperature = 25;
     adcval.load_current = 1;
-    adcval.mcu_temperature = 25;
     adcval.solar_voltage = 30;
     prepare_adc_readings(adcval);
 

--- a/test/tests_load.cpp
+++ b/test/tests_load.cpp
@@ -40,13 +40,13 @@ void disabled_to_off_bat_temp_if_error_flag_set()
     // overtemp
     log_data.error_flags = 1 << ERR_BAT_CHG_OVERTEMP;
     load.state_machine();
-    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_BAT_TEMP, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.state);
 
     // undertemp
     load.state = LOAD_STATE_DISABLED;
     log_data.error_flags = 1 << ERR_BAT_CHG_UNDERTEMP;
     load.state_machine();
-    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_BAT_TEMP, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.state);
 }
 
 void off_low_soc_to_on_after_delay()
@@ -146,12 +146,12 @@ void on_to_off_bat_temp_if_error_flag_set()
     load.state = LOAD_STATE_ON;
     log_data.error_flags = 1 << ERR_BAT_DIS_OVERTEMP;
     load.state_machine();
-    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_BAT_TEMP, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.state);
 
     load.state = LOAD_STATE_ON;
     log_data.error_flags = 1 << ERR_BAT_DIS_UNDERTEMP;
     load.state_machine();
-    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_BAT_TEMP, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.state);
 }
 
 void on_to_disabled_if_enable_false()
@@ -225,6 +225,7 @@ void control_off_voltage_dip()
     PowerPort port;
     LoadOutput load(&port);
     port.init_load(14.6);
+    port.current = 0;
     load.voltage_prev = port.voltage;
     load.state = LOAD_STATE_ON;
     internal_temp = 25;
@@ -239,6 +240,22 @@ void control_off_voltage_dip()
     load.control();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_OVERCURRENT, load.state);
     TEST_ASSERT_EQUAL(1 << ERR_LOAD_VOLTAGE_DIP, log_data.error_flags);
+}
+
+void control_off_temperature()
+{
+    PowerPort port;
+    LoadOutput load(&port);
+    port.init_load(14.6);
+    port.current = 0;
+    load.voltage_prev = port.voltage;
+    load.state = LOAD_STATE_ON;
+    internal_temp = 25;
+    load.junction_temperature = 25;
+    log_data.error_flags = 1U << ERR_INT_OVERTEMP;
+
+    load.control();
+    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.state);
 }
 
 void load_tests()
@@ -261,6 +278,7 @@ void load_tests()
     RUN_TEST(control_off_overvoltage);
     RUN_TEST(control_off_overcurrent);
     RUN_TEST(control_off_voltage_dip);
+    RUN_TEST(control_off_temperature);
 
     // ToDo: What to do if port current is above the limit, but the hardware can still handle it?
 

--- a/test/tests_load.cpp
+++ b/test/tests_load.cpp
@@ -28,6 +28,7 @@ void disabled_to_off_low_soc_if_error_flag_set()
     log_data.error_flags = 1 << ERR_BAT_UNDERVOLTAGE;
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_LOW_SOC, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_LOW_SOC, load.usb_state);
 }
 
 void disabled_to_off_bat_temp_if_error_flag_set()
@@ -41,12 +42,14 @@ void disabled_to_off_bat_temp_if_error_flag_set()
     log_data.error_flags = 1 << ERR_BAT_CHG_OVERTEMP;
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.usb_state);
 
     // undertemp
     load.state = LOAD_STATE_DISABLED;
     log_data.error_flags = 1 << ERR_BAT_CHG_UNDERTEMP;
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.usb_state);
 }
 
 void off_low_soc_to_on_after_delay()
@@ -55,16 +58,19 @@ void off_low_soc_to_on_after_delay()
     LoadOutput load(&port);
     port.init_load(14.6);
     load.state = LOAD_STATE_OFF_LOW_SOC;
+    load.usb_state = LOAD_STATE_OFF_LOW_SOC;
     port.pos_current_limit = 10;
 
     load.lvd_timestamp = time(NULL) - load.lvd_recovery_delay + 1;
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_LOW_SOC, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_LOW_SOC, load.usb_state);
 
     load.lvd_timestamp = time(NULL) - load.lvd_recovery_delay - 1;
     load.state_machine();
     load.state_machine();   // call twice as it goes through disabled state
     TEST_ASSERT_EQUAL(LOAD_STATE_ON, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_ON, load.usb_state);
 }
 
 void off_overcurrent_to_on_after_delay()
@@ -73,16 +79,19 @@ void off_overcurrent_to_on_after_delay()
     LoadOutput load(&port);
     port.init_load(14.6);
     load.state = LOAD_STATE_OFF_OVERCURRENT;
+    load.usb_state = LOAD_STATE_ON;
     port.pos_current_limit = 10;
 
     load.overcurrent_timestamp = time(NULL) - load.overcurrent_recovery_delay + 1;
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_OVERCURRENT, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_ON, load.usb_state);       // not affected by overcurrent
 
     load.overcurrent_timestamp = time(NULL) - load.overcurrent_recovery_delay - 1;
     load.state_machine();
     load.state_machine();   // call twice as it goes through disabled state
     TEST_ASSERT_EQUAL(LOAD_STATE_ON, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_ON, load.usb_state);
 }
 
 void off_overvoltage_to_on_at_lower_voltage()
@@ -92,10 +101,12 @@ void off_overvoltage_to_on_at_lower_voltage()
     port.init_load(14.6);
     port.pos_current_limit = 10;
     load.state = LOAD_STATE_OFF_OVERVOLTAGE;
+    load.usb_state = LOAD_STATE_ON;
     port.voltage = port.sink_voltage_max + 0.1;
 
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_OVERVOLTAGE, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_ON, load.usb_state);       // not affected by overvoltage
 
     port.voltage = port.sink_voltage_max - 0.1;     // test hysteresis
     load.state_machine();
@@ -105,6 +116,7 @@ void off_overvoltage_to_on_at_lower_voltage()
     load.state_machine();
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_ON, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_ON, load.usb_state);
 }
 
 void off_short_circuit_to_disabled()
@@ -114,13 +126,16 @@ void off_short_circuit_to_disabled()
     port.init_load(14.6);
     port.pos_current_limit = 10;
     load.state = LOAD_STATE_OFF_SHORT_CIRCUIT;
+    load.usb_state = LOAD_STATE_ON;
 
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_SHORT_CIRCUIT, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_ON, load.usb_state);       // not affected by overvoltage
 
     load.enable = false;        // this is like a manual reset
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_DISABLED, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_ON, load.usb_state);
 }
 
 void on_to_off_low_soc_if_error_flag_set()
@@ -129,11 +144,13 @@ void on_to_off_low_soc_if_error_flag_set()
     LoadOutput load(&port);
     port.init_load(14.6);
     load.state = LOAD_STATE_ON;
+    load.usb_state = LOAD_STATE_ON;
     port.pos_current_limit = 0;
     log_data.error_flags = 1 << ERR_BAT_UNDERVOLTAGE;
 
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_LOW_SOC, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_LOW_SOC, load.usb_state);
 }
 
 void on_to_off_bat_temp_if_error_flag_set()
@@ -144,14 +161,17 @@ void on_to_off_bat_temp_if_error_flag_set()
     port.pos_current_limit = 0;
 
     load.state = LOAD_STATE_ON;
+    load.usb_state = LOAD_STATE_ON;
     log_data.error_flags = 1 << ERR_BAT_DIS_OVERTEMP;
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.usb_state);
 
     load.state = LOAD_STATE_ON;
     log_data.error_flags = 1 << ERR_BAT_DIS_UNDERTEMP;
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.usb_state);
 }
 
 void on_to_disabled_if_enable_false()
@@ -162,12 +182,19 @@ void on_to_disabled_if_enable_false()
     port.pos_current_limit = 10;
 
     load.state = LOAD_STATE_ON;
+    load.usb_state = LOAD_STATE_ON;
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_ON, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_ON, load.usb_state);
 
     load.enable = false;
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_DISABLED, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_ON, load.usb_state);
+
+    load.usb_enable = false;
+    load.state_machine();
+    TEST_ASSERT_EQUAL(LOAD_STATE_DISABLED, load.usb_state);
 }
 
 void control_off_overvoltage()
@@ -281,8 +308,6 @@ void load_tests()
     RUN_TEST(control_off_temperature);
 
     // ToDo: What to do if port current is above the limit, but the hardware can still handle it?
-
-    // ToDo: Additional USB output state machine tests
 
     UNITY_END();
 }

--- a/test/tests_load.cpp
+++ b/test/tests_load.cpp
@@ -192,7 +192,7 @@ void control_off_overvoltage()
     TEST_ASSERT_EQUAL(1 << ERR_LOAD_OVERVOLTAGE, log_data.error_flags);
 }
 
-extern float mcu_temp;
+extern float internal_temp;
 
 void control_off_overcurrent()
 {
@@ -204,7 +204,7 @@ void control_off_overcurrent()
     port.voltage = 14;
     load.state = LOAD_STATE_ON;
     load.voltage_prev = port.voltage;
-    mcu_temp = 25;
+    internal_temp = 25;
     load.junction_temperature = 25;
     log_data.error_flags = 0;
 
@@ -227,7 +227,7 @@ void control_off_voltage_dip()
     port.init_load(14.6);
     load.voltage_prev = port.voltage;
     load.state = LOAD_STATE_ON;
-    mcu_temp = 25;
+    internal_temp = 25;
     load.junction_temperature = 25;
     log_data.error_flags = 0;
 

--- a/test/tests_log.cpp
+++ b/test/tests_log.cpp
@@ -106,11 +106,11 @@ void log_new_bat_temp_max()
     TEST_ASSERT_EQUAL(45, log_data.bat_temp_max);
 }
 
-extern float mcu_temp;
+extern float internal_temp;
 
 void log_new_int_temp_max()
 {
-    mcu_temp = 22;
+    internal_temp = 22;
     log_update_min_max_values(&log_data);
     TEST_ASSERT_EQUAL(22, log_data.int_temp_max);
 }

--- a/test/tests_power_port.cpp
+++ b/test/tests_power_port.cpp
@@ -33,7 +33,7 @@ void energy_calculation_init()
     adcval.dcdc_current = dcdc_current_sun;
     adcval.internal_temperature = 25;
     adcval.load_current = load_current;
-    adcval.mcu_temperature = 25;
+    adcval.internal_temperature = 25;
     adcval.solar_voltage = 30;
 
     // insert values into ADC functions


### PR DESCRIPTION
Summary of changes:

- Switched back to older mbed version, as the update broke load short circuit comparator function
- Added voltage dip detection to disconnect load if charge controller is connected to small battery or with bad wires and short circuit detection doesn't trigger
- Added more error flags to diagnose reasons for load disconnect
- Overcurrent and short circuit are now both displayed with flickering load LED. Rationale: "normal" load disconnects caused by empty battery are indicated with the LED being switched off. Load disconnect caused by user errors (like short circuit or connecting loads that consume too much power) are indicated by flickering LED, i.e. more annoying and like a warning.

For switching on a disabled loads we currently have the following rules:

- Overvoltage: Automatically after voltage is lower again
- Undervoltage (i.e. battery empty): After one hour if voltage raised again. Should this be decreased?
- Overcurrent: After 5 minutes it tries to switch on again.
- Short circuit: Charge controller needs manual reset (power down) or one disable/enable signal via communication interface to make sure that the short circuit has been removed.
