### PR TITLE
Use methods to set/clear/query error flags

### DIFF
--- a/src/adc_dma.cpp
+++ b/src/adc_dma.cpp
@@ -176,11 +176,11 @@ void update_measurements()
         (TSENSE_CAL2 - TSENSE_CAL1) * (adcval - TSENSE_CAL1) + TSENSE_CAL1_VALUE;
 
     if (dev_stat.internal_temp > 80) {
-        dev_stat.error_flags |= 1U << ERR_INT_OVERTEMP;
+        dev_stat.set_error(ERR_INT_OVERTEMP);
     }
-    else if (dev_stat.internal_temp < 70 && (dev_stat.error_flags & (1U << ERR_INT_OVERTEMP))) {
+    else if (dev_stat.internal_temp < 70 && (dev_stat.has_error(ERR_INT_OVERTEMP))) {
         // remove error flag with hysteresis of 10°C
-        dev_stat.error_flags &= ~(1U << ERR_INT_OVERTEMP);
+        dev_stat.clear_error(ERR_INT_OVERTEMP);
     }
     // else: keep previous setting
 }

--- a/src/bat_charger.cpp
+++ b/src/bat_charger.cpp
@@ -277,7 +277,7 @@ void Charger::discharge_control(BatConf *bat_conf)
             // low state of charge
             port->neg_current_limit = 0;
             num_deep_discharges++;
-            dev_stat.error_flags |= (1 << ERR_BAT_UNDERVOLTAGE);
+            dev_stat.set_error(ERR_BAT_UNDERVOLTAGE);
 
             if (usable_capacity < 0.1) {
                 // reset to measured value if discharged the first time
@@ -297,11 +297,11 @@ void Charger::discharge_control(BatConf *bat_conf)
         }
         else if (bat_temperature > bat_conf->discharge_temp_max) {
             port->neg_current_limit = 0;
-            dev_stat.error_flags |= (1 << ERR_BAT_DIS_OVERTEMP);
+            dev_stat.set_error(ERR_BAT_DIS_OVERTEMP);
         }
         else if (bat_temperature < bat_conf->discharge_temp_min) {
             port->neg_current_limit = 0;
-            dev_stat.error_flags |= (1 << ERR_BAT_DIS_UNDERTEMP);
+            dev_stat.set_error(ERR_BAT_DIS_UNDERTEMP);
         }
     }
     else {
@@ -316,9 +316,9 @@ void Charger::discharge_control(BatConf *bat_conf)
             port->neg_current_limit = -bat_conf->discharge_current_max;
 
             // delete all discharge error flags
-            dev_stat.error_flags &= ~(1 << ERR_BAT_DIS_OVERTEMP);
-            dev_stat.error_flags &= ~(1 << ERR_BAT_DIS_UNDERTEMP);
-            dev_stat.error_flags &= ~(1 << ERR_BAT_UNDERVOLTAGE);
+            dev_stat.clear_error(ERR_BAT_DIS_OVERTEMP);
+            dev_stat.clear_error(ERR_BAT_DIS_UNDERTEMP);
+            dev_stat.clear_error(ERR_BAT_UNDERVOLTAGE);
         }
     }
 }
@@ -328,12 +328,12 @@ void Charger::charge_control(BatConf *bat_conf)
     // check battery temperature for charging direction
     if (bat_temperature > bat_conf->charge_temp_max) {
         port->pos_current_limit = 0;
-        dev_stat.error_flags |= (1 << ERR_BAT_CHG_OVERTEMP);
+        dev_stat.set_error(ERR_BAT_CHG_OVERTEMP);
         enter_state(CHG_STATE_IDLE);
     }
     else if (bat_temperature < bat_conf->charge_temp_min) {
         port->pos_current_limit = 0;
-        dev_stat.error_flags |= (1 << ERR_BAT_CHG_UNDERTEMP);
+        dev_stat.set_error(ERR_BAT_CHG_UNDERTEMP);
         enter_state(CHG_STATE_IDLE);
     }
 
@@ -349,8 +349,8 @@ void Charger::charge_control(BatConf *bat_conf)
                     bat_conf->temperature_compensation * (bat_temperature - 25));
                 port->pos_current_limit = bat_conf->charge_current_max;
                 full = false;
-                dev_stat.error_flags &= ~(1 << ERR_BAT_CHG_OVERTEMP);
-                dev_stat.error_flags &= ~(1 << ERR_BAT_CHG_UNDERTEMP);
+                dev_stat.clear_error(ERR_BAT_CHG_OVERTEMP);
+                dev_stat.clear_error(ERR_BAT_CHG_UNDERTEMP);
                 enter_state(CHG_STATE_BULK);
             }
             break;

--- a/src/device_status.h
+++ b/src/device_status.h
@@ -90,6 +90,10 @@ public:
     // instantaneous device-level data
     uint32_t error_flags;       ///< Currently detected errors
     float internal_temp;        ///< Internal temperature (measured in MCU)
+
+    void set_error(ErrorFlag e) { error_flags |= (1U << e); }
+    void clear_error(ErrorFlag e) { error_flags &= ~(1U << e); }
+    bool has_error(ErrorFlag e) { return (error_flags & (1U << e)) != 0; }
 };
 
 #endif /* DEVICE_STATUS_H */

--- a/test/tests_load.cpp
+++ b/test/tests_load.cpp
@@ -25,7 +25,8 @@ void disabled_to_off_low_soc_if_error_flag_set()
     LoadOutput load(&port);
     port.init_load(14.6);
     port.pos_current_limit = 0;
-    dev_stat.error_flags = 1 << ERR_BAT_UNDERVOLTAGE;
+    dev_stat.error_flags = 0;
+    dev_stat.set_error(ERR_BAT_UNDERVOLTAGE);
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_LOW_SOC, load.state);
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_LOW_SOC, load.usb_state);
@@ -39,14 +40,16 @@ void disabled_to_off_bat_temp_if_error_flag_set()
     port.pos_current_limit = 0;
 
     // overtemp
-    dev_stat.error_flags = 1 << ERR_BAT_CHG_OVERTEMP;
+    dev_stat.dev_stat. = 0;
+    dev_stat.set_error(ERR_BAT_CHG_OVERTEMP);
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.state);
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.usb_state);
 
     // undertemp
     load.state = LOAD_STATE_DISABLED;
-    dev_stat.error_flags = 1 << ERR_BAT_CHG_UNDERTEMP;
+    dev_stat.error_flags = 0; 
+    dev_stat.set_error(ERR_BAT_CHG_UNDERTEMP);
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.state);
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.usb_state);
@@ -146,7 +149,8 @@ void on_to_off_low_soc_if_error_flag_set()
     load.state = LOAD_STATE_ON;
     load.usb_state = LOAD_STATE_ON;
     port.pos_current_limit = 0;
-    dev_stat.error_flags = 1 << ERR_BAT_UNDERVOLTAGE;
+    dev_stat.error_flags = 0; 
+    dev_stat.set_error(ERR_BAT_UNDERVOLTAGE);
 
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_LOW_SOC, load.state);
@@ -162,13 +166,15 @@ void on_to_off_bat_temp_if_error_flag_set()
 
     load.state = LOAD_STATE_ON;
     load.usb_state = LOAD_STATE_ON;
-    dev_stat.error_flags = 1 << ERR_BAT_DIS_OVERTEMP;
+    dev_stat.error_flags = 0; 
+    dev_stat.set_error(ERR_BAT_DIS_OVERTEMP);
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.state);
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.usb_state);
 
     load.state = LOAD_STATE_ON;
-    dev_stat.error_flags = 1 << ERR_BAT_DIS_UNDERTEMP;
+    dev_stat.error_flags = 0;
+    dev_stat.set_error(ERR_BAT_DIS_UNDERTEMP);
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.state);
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.usb_state);
@@ -277,7 +283,8 @@ void control_off_temperature()
     load.state = LOAD_STATE_ON;
     dev_stat.internal_temp = 25;
     load.junction_temperature = 25;
-    dev_stat.error_flags = 1U << ERR_INT_OVERTEMP;
+    dev_stat.error_flags = 0;
+    dev_stat.set_error(ERR_INT_OVERTEMP);
 
     load.control();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.state);

--- a/test/tests_load.cpp
+++ b/test/tests_load.cpp
@@ -40,7 +40,7 @@ void disabled_to_off_bat_temp_if_error_flag_set()
     port.pos_current_limit = 0;
 
     // overtemp
-    dev_stat.dev_stat. = 0;
+    dev_stat.error_flags = 0;
     dev_stat.set_error(ERR_BAT_CHG_OVERTEMP);
     load.state_machine();
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF_TEMPERATURE, load.state);


### PR DESCRIPTION
Easier to read, quicker to write (if using code
completion), no performance loss due to inlining.