### PR TITLE
ADC alerts for faster over/undervoltage detection

### DIFF
--- a/src/adc_dma.h
+++ b/src/adc_dma.h
@@ -31,12 +31,12 @@
 /** Struct to definie upper and lower limit alerts for any ADC channel
  */
 typedef struct {
-    void *callback = NULL;                  ///< Function to be called when limits are exceeded
+    //bool enable = false;                    ///< Can be used to temporarily disable this alert
+    void *callback_upper = NULL;            ///< Function to be called when limits are exceeded
+    void *callback_lower = NULL;            ///< Function to be called when limits are exceeded
     uint16_t upper_limit = UINT16_MAX;      ///< ADC reading for upper limit
     uint16_t lower_limit = 0;               ///< ADC reading for lower limit
-    uint32_t err_flag_upper = 0;            ///< Error flag to raise at upper limit
-    uint32_t err_flag_lower = 0;            ///< Error flag to raise at lower limit
-    int debounce_counter;                   ///< Can be used to prevent triggering at fist occurence
+    int debounce_ms = 0;                    ///< Milliseconds delay for triggering alert
 } AdcAlert;
 
 /** Sets offset to actual measured value, i.e. sets zero current point.
@@ -65,8 +65,18 @@ void dma_setup(void);
  */
 void adc_update_value(unsigned int pos);
 
-/** Set limits where an alert should be triggered after reading the ADC values
+/** Set lv side (battery) voltage limits where an alert should be triggered
+ *
+ * @param upper Upper voltage limit
+ * @param lower Lower voltage limit
  */
-void adc_set_alerts();
+void adc_set_lv_alerts(float upper, float lower);
+
+/** Add an inhibit delay to the alerts to disable it temporarily
+ *
+ * @param adc_pos The position of the ADC measurement channel
+ * @param timeout_ms Timeout in milliseconds
+ */
+void adc_alert_inhibit(int adc_pos, int timeout_ms);
 
 #endif /* ADC_DMA */

--- a/src/adc_dma.h
+++ b/src/adc_dma.h
@@ -50,4 +50,8 @@ void adc_setup(void);
  */
 void dma_setup(void);
 
+/** Read, filter and check raw ADC readings stored by DMA controller
+ */
+void adc_update_value(unsigned int pos);
+
 #endif /* ADC_DMA */

--- a/src/adc_dma.h
+++ b/src/adc_dma.h
@@ -28,6 +28,17 @@
 
 #define ADC_FILTER_CONST 5          // filter multiplier = 1/(2^ADC_FILTER_CONST)
 
+/** Struct to definie upper and lower limit alerts for any ADC channel
+ */
+typedef struct {
+    void *callback = NULL;                  ///< Function to be called when limits are exceeded
+    uint16_t upper_limit = UINT16_MAX;      ///< ADC reading for upper limit
+    uint16_t lower_limit = 0;               ///< ADC reading for lower limit
+    uint32_t err_flag_upper = 0;            ///< Error flag to raise at upper limit
+    uint32_t err_flag_lower = 0;            ///< Error flag to raise at lower limit
+    int debounce_counter;                   ///< Can be used to prevent triggering at fist occurence
+} AdcAlert;
+
 /** Sets offset to actual measured value, i.e. sets zero current point.
  *
  * All input/output switches and consumers should be switched off before calling this function
@@ -53,5 +64,9 @@ void dma_setup(void);
 /** Read, filter and check raw ADC readings stored by DMA controller
  */
 void adc_update_value(unsigned int pos);
+
+/** Set limits where an alert should be triggered after reading the ADC values
+ */
+void adc_set_alerts();
 
 #endif /* ADC_DMA */

--- a/src/bat_charger.cpp
+++ b/src/bat_charger.cpp
@@ -351,6 +351,7 @@ void Charger::charge_control(BatConf *bat_conf)
                 full = false;
                 dev_stat.clear_error(ERR_BAT_CHG_OVERTEMP);
                 dev_stat.clear_error(ERR_BAT_CHG_UNDERTEMP);
+                dev_stat.clear_error(ERR_BAT_OVERVOLTAGE);
                 enter_state(CHG_STATE_BULK);
             }
             break;

--- a/src/dcdc.cpp
+++ b/src/dcdc.cpp
@@ -137,6 +137,7 @@ int Dcdc::check_start_conditions()
         hvs->voltage > hs_voltage_max ||   // also critical for buck mode because of ringing
         lvs->voltage > ls_voltage_max ||
         lvs->voltage < ls_voltage_min ||
+        dev_stat.has_error(ERR_BAT_UNDERVOLTAGE | ERR_BAT_OVERVOLTAGE) ||
         time(NULL) < (off_timestamp + restart_interval))
     {
         return 0;       // no energy transfer allowed
@@ -267,6 +268,13 @@ void Dcdc::test()
             startup_delay_counter++;
         }
     }
+}
+
+void Dcdc::emergency_stop()
+{
+    half_bridge_stop();
+    state = DCDC_STATE_OFF;
+    off_timestamp = time(NULL);
 }
 
 void Dcdc::self_destruction()

--- a/src/dcdc.h
+++ b/src/dcdc.h
@@ -88,6 +88,12 @@ public:
      */
     void test();
 
+    /** Fast emergency stop function
+     *
+     * May be called from an ISR which detected overvoltage / overcurrent conditions
+     */
+    void emergency_stop();
+
     /** Prevent overcharging of battery in case of shorted HS MOSFET
      *
      * This function switches the LS MOSFET continuously on to blow the battery input fuse. The

--- a/src/load.cpp
+++ b/src/load.cpp
@@ -260,7 +260,9 @@ void LoadOutput::state_machine()
     switch (state) {
         case LOAD_STATE_DISABLED:
             if (enable == true) {
-                if (port->pos_current_limit > 0) {
+                if (port->pos_current_limit > 0 &&
+                    !dev_stat.has_error(ERR_BAT_UNDERVOLTAGE | ERR_BAT_OVERVOLTAGE))
+                {
                     switch_set(true);
                     state = LOAD_STATE_ON;
                 }
@@ -406,4 +408,11 @@ void LoadOutput::control()
     else {
         debounce_counter = 0;
     }
+}
+
+void LoadOutput::emergency_stop(uint16_t next_state)
+{
+    switch_set(false);
+    leds_flicker(LED_LOAD);
+    state = next_state;
 }

--- a/src/load.h
+++ b/src/load.h
@@ -80,6 +80,14 @@ public:
      */
     void control();
 
+    /** Fast emergency stop function
+     *
+     * May be called from an ISR which detected overvoltage / overcurrent conditions
+     *
+     * @param next_state Select state the load should go to
+     */
+    void emergency_stop(uint16_t next_state = LOAD_STATE_DISABLED);
+
     uint16_t state;             ///< Current state of load output switch
     uint16_t usb_state;         ///< Current state of USB output
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -165,6 +165,8 @@ int main()
 
             load.state_machine();
 
+            adc_set_alerts();       // update regularly to cover changed configurations
+
             eeprom_update();
 
             leds_update_1s();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -165,7 +165,9 @@ int main()
 
             load.state_machine();
 
-            adc_set_alerts();       // update regularly to cover changed configurations
+            // update regularly to cover changed battery configurations
+            adc_set_lv_alerts(bat_conf.voltage_absolute_max * charger.num_batteries,
+                bat_conf.voltage_absolute_min * charger.num_batteries);
 
             eeprom_update();
 

--- a/src/pwm_switch.cpp
+++ b/src/pwm_switch.cpp
@@ -209,6 +209,12 @@ void PwmSwitch::control()
     }
 }
 
+void PwmSwitch::emergency_stop()
+{
+    pwm_signal_stop();
+    off_timestamp = time(NULL);
+}
+
 float PwmSwitch::get_duty_cycle()
 {
     return pwm_signal_get_duty_cycle();

--- a/src/pwm_switch.cpp
+++ b/src/pwm_switch.cpp
@@ -108,6 +108,11 @@ void pwm_signal_stop()
     _pwm_active = false;
 }
 
+bool pwm_signal_high()
+{
+    return (GPIOB->IDR & GPIO_PIN_1);
+}
+
 #else
 
 // dummy functions for unit tests
@@ -117,12 +122,18 @@ void pwm_signal_duty_cycle_step(int delta) {;}
 void pwm_signal_init_registers(int freq_Hz) {;}
 void pwm_signal_start(float pwm_duty) {;}
 void pwm_signal_stop() {;}
+bool pwm_signal_high() { return false; }
 
 #endif
 
 bool PwmSwitch::active()
 {
     return _pwm_active;
+}
+
+bool PwmSwitch::signal_high()
+{
+    return pwm_signal_high();
 }
 
 PwmSwitch::PwmSwitch(PowerPort *pwm_terminal, PowerPort *pwm_port_int)

--- a/src/pwm_switch.cpp
+++ b/src/pwm_switch.cpp
@@ -18,6 +18,8 @@
 #include "config.h"
 #include "pcb.h"
 
+#include "adc_dma.h"
+
 #include <stdio.h>
 #include <time.h>       // for time(NULL) function
 
@@ -203,6 +205,8 @@ void PwmSwitch::control()
             && time(NULL) > (off_timestamp + restart_interval)
             && enabled == true)
         {
+            // turning the PWM switch on creates a short voltage rise, so inhibit alerts by 100 ms
+            adc_alert_inhibit(ADC_POS_V_BAT, 100);
             pwm_signal_start(1);
             printf("PWM charger start.\n");
         }

--- a/src/pwm_switch.h
+++ b/src/pwm_switch.h
@@ -41,11 +41,17 @@ public:
      */
     void control();
 
-    /** Read the on/off status of the PWM switch
+    /** Read the general on/off status of PWM switching
      *
      * @returns true if on
      */
     bool active();
+
+    /** Read the current high or low state of the PWM signal
+     *
+     * @returns true if high, false if low
+     */
+    bool signal_high();
 
     /** Read the currently set duty cycle
      *

--- a/src/pwm_switch.h
+++ b/src/pwm_switch.h
@@ -41,6 +41,12 @@ public:
      */
     void control();
 
+    /** Fast emergency stop function
+     *
+     * May be called from an ISR which detected overvoltage / overcurrent conditions
+     */
+    void emergency_stop();
+
     /** Read the general on/off status of PWM switching
      *
      * @returns true if on

--- a/test/adc_dma_stub.cpp
+++ b/test/adc_dma_stub.cpp
@@ -22,14 +22,22 @@
 #include <stdint.h>
 #include <stdio.h>
 
+extern uint16_t adc_readings[NUM_ADC_CH];
 extern uint32_t adc_filtered[NUM_ADC_CH];
 
-
-void prepare_adc_readings(adc_values_t values)
+void prepare_adc_readings(AdcValues values)
 {
-    adc_filtered[ADC_POS_VREF_MCU] = (uint32_t)(1.224 / 3.3 * 4096) << (4 + ADC_FILTER_CONST);
-    adc_filtered[ADC_POS_V_SOLAR] = (uint32_t)((values.solar_voltage / (ADC_GAIN_V_SOLAR)) / 3.3 * 4096) << (4 + ADC_FILTER_CONST);
-    adc_filtered[ADC_POS_V_BAT] = (uint32_t)((values.battery_voltage / (ADC_GAIN_V_BAT)) / 3.3 * 4096) << (4 + ADC_FILTER_CONST);
-    adc_filtered[ADC_POS_I_DCDC] = (uint32_t)((values.dcdc_current / (ADC_GAIN_I_DCDC)) / 3.3 * 4096) << (4 + ADC_FILTER_CONST);
-    adc_filtered[ADC_POS_I_LOAD] = (uint32_t)((values.load_current / (ADC_GAIN_I_LOAD)) / 3.3 * 4096) << (4 + ADC_FILTER_CONST);
+    adc_readings[ADC_POS_VREF_MCU] = (uint16_t)(1.224 / 3.3 * 4096) << 4;
+    adc_readings[ADC_POS_V_SOLAR] = (uint16_t)((values.solar_voltage / (ADC_GAIN_V_SOLAR)) / 3.3 * 4096) << 4;
+    adc_readings[ADC_POS_V_BAT] = (uint16_t)((values.battery_voltage / (ADC_GAIN_V_BAT)) / 3.3 * 4096) << 4;
+    adc_readings[ADC_POS_I_DCDC] = (uint16_t)((values.dcdc_current / (ADC_GAIN_I_DCDC)) / 3.3 * 4096) << 4;
+    adc_readings[ADC_POS_I_LOAD] = (uint16_t)((values.load_current / (ADC_GAIN_I_LOAD)) / 3.3 * 4096) << 4;
+}
+
+void prepare_adc_filtered()
+{
+    // initialize also filtered values
+    for (int i = 0; i < NUM_ADC_CH; i++) {
+        adc_filtered[i] = adc_readings[i] << ADC_FILTER_CONST;
+    }
 }

--- a/test/adc_dma_stub.h
+++ b/test/adc_dma_stub.h
@@ -25,6 +25,8 @@ typedef struct {
     float load_current;
     float bat_temperature;
     float internal_temperature;
-} adc_values_t;
+} AdcValues;
 
-void prepare_adc_readings(adc_values_t values);
+void prepare_adc_readings(AdcValues values);
+
+void prepare_adc_filtered();

--- a/test/tests_adc_dma.cpp
+++ b/test/tests_adc_dma.cpp
@@ -70,7 +70,7 @@ void adc_alert_undervoltage_triggering()
 {
     dev_stat.clear_error(ERR_ANY_ERROR);
     battery_conf_init(&bat_conf, BAT_TYPE_LFP, 4, 100);
-    adc_set_alerts();
+    adc_set_lv_alerts(bat_conf.voltage_absolute_max, bat_conf.voltage_absolute_min);
     prepare_adc_filtered();
     adc_update_value(ADC_POS_V_BAT);
 
@@ -81,9 +81,7 @@ void adc_alert_undervoltage_triggering()
     TEST_ASSERT_EQUAL(false, dev_stat.has_error(ERR_BAT_UNDERVOLTAGE));
     adc_update_value(ADC_POS_V_BAT);
     TEST_ASSERT_EQUAL(true, dev_stat.has_error(ERR_BAT_UNDERVOLTAGE));
-    TEST_ASSERT_EQUAL(false, pwm_switch.active());
-    TEST_ASSERT_EQUAL(DCDC_STATE_OFF, dcdc.state);
-    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_SHORT_CIRCUIT, load.state);
+    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_OVERCURRENT, load.state);
 
     // reset values
     adcval.battery_voltage = 13;
@@ -99,9 +97,11 @@ void adc_alert_overvoltage_triggering()
 {
     dev_stat.clear_error(ERR_ANY_ERROR);
     battery_conf_init(&bat_conf, BAT_TYPE_LFP, 4, 100);
-    adc_set_alerts();
+    adc_set_lv_alerts(bat_conf.voltage_absolute_max, bat_conf.voltage_absolute_min);
     prepare_adc_filtered();
     adc_update_value(ADC_POS_V_BAT);
+
+    dcdc.state = DCDC_STATE_MPPT;
 
     // overvoltage test
     adcval.battery_voltage = bat_conf.voltage_absolute_max + 0.1;
@@ -112,7 +112,6 @@ void adc_alert_overvoltage_triggering()
     TEST_ASSERT_EQUAL(true, dev_stat.has_error(ERR_BAT_OVERVOLTAGE));
     TEST_ASSERT_EQUAL(false, pwm_switch.active());
     TEST_ASSERT_EQUAL(DCDC_STATE_OFF, dcdc.state);
-    TEST_ASSERT_EQUAL(LOAD_STATE_OFF_OVERVOLTAGE, load.state);
 
     // reset values
     adcval.battery_voltage = 12;

--- a/test/tests_device_status.cpp
+++ b/test/tests_device_status.cpp
@@ -108,6 +108,7 @@ void dev_stat_new_bat_temp_max()
 
 void dev_stat_new_int_temp_max()
 {
+    dev_stat.int_temp_max = 20;
     dev_stat.internal_temp = 22;
     dev_stat.update_min_max_values();
     TEST_ASSERT_EQUAL(22, dev_stat.int_temp_max);

--- a/test/tests_power_port.cpp
+++ b/test/tests_power_port.cpp
@@ -9,7 +9,7 @@
 
 #include "main.h"
 
-static adc_values_t adcval;
+static AdcValues adcval;
 
 const float dcdc_current_sun = 3;
 const float load_current = 1;
@@ -38,6 +38,7 @@ void energy_calculation_init()
 
     // insert values into ADC functions
     prepare_adc_readings(adcval);
+    prepare_adc_filtered();
     update_measurements();
 
     for (int i = 0; i < 60*60*sun_hours; i++) {
@@ -49,6 +50,7 @@ void energy_calculation_init()
     // disable DC/DC = solar charging
     adcval.dcdc_current = 0;
     prepare_adc_readings(adcval);
+    prepare_adc_filtered();
     update_measurements();
 
     for (int i = 0; i < 60*60*night_hours; i++) {


### PR DESCRIPTION
Most important reason for this PR: If the battery is disconnected while the PWM charge controller is charging, the voltage will rise quickly to the solar input voltage and the load output should be disconnected immediately to prevent connected devices from overvoltage. Previous overvoltage detection mechanisms were too slow.

Below implementation compares the raw ADC captures vs. previously calculated limits. There is also a hardware implementation for this in STM32 MCUs, but for the ones we are using it allows to set only one generic limit, not per ADC pin.

Risk of using ADC values without filtering: A voltage spike could trigger false positives. Suggesting a debounce counter to capture at least two measurements with exceeded limits. The ADC runs at 1 kHz, so this would mean 2 ms delay.

General remark: The global error states together with different state machines (PWM switch, load, DC/DC) are getting quite confusing. We'll need to unify / clean up this somehow in the future.