### PR TITLE
Fix for ADC randomly misconfigured

### DIFF
--- a/src/adc_dma.cpp
+++ b/src/adc_dma.cpp
@@ -349,7 +349,7 @@ void adc_setup()
     solar_en = 1;
 #endif
 
-    ADC_HandleTypeDef hadc;
+    ADC_HandleTypeDef hadc = {0};
     ADC_ChannelConfTypeDef sConfig = {0};
 
     __HAL_RCC_ADC1_CLK_ENABLE();


### PR DESCRIPTION
This issue happened because the HAL ADC configuration data structure
is allocated on the stack (which by default is not initialized,
i.e. contains potentially non-zero data). As most of this structure was
explicitly initialized only sometimes the now added OversampleMode setting was
not 0, in this case the ADC had no left data alignment, i.e. delivered
to low values.

If it happens, the system sees very weird temperature and
voltage/power values.
Fix was simple. Effectively the zero initalization would be enough here.
But explicitly disabling the OverSampleMode doesn't hurt either.