### PR TITLE
OLED display brightness adjust, reset improvement, SOC display and more

### DIFF
--- a/src/adc_dma.cpp
+++ b/src/adc_dma.cpp
@@ -349,7 +349,7 @@ void adc_setup()
     solar_en = 1;
 #endif
 
-    ADC_HandleTypeDef hadc;
+    ADC_HandleTypeDef hadc = {0};
     ADC_ChannelConfTypeDef sConfig = {0};
 
     __HAL_RCC_ADC1_CLK_ENABLE();

--- a/src/config.h_template
+++ b/src/config.h_template
@@ -47,6 +47,9 @@
 
 // OLED display at UEXT port
 //#define OLED_ENABLED
+// OLED Brightness (value 0x01-0xff or 1-255)
+// leave undefined to use default
+//#define OLED_BRIGHTNESS 0x1
 
 // UART serial at SWD connector
 #define UART_SERIAL_ENABLED

--- a/src/uext/uext_oled.cpp
+++ b/src/uext/uext_oled.cpp
@@ -56,6 +56,30 @@ void UExtOled::enable() {
     DigitalOut uext_dis(PIN_UEXT_DIS);
     uext_dis = 0;
 #endif
+/**
+ * 1.Display is OFF 
+ * 2.128 x 64 Display Mode 
+ * 3.Normal segment and display data column address and row address mapping 
+ *   (SEG0 mapped to address 00h and COM0 mapped to address 00h)
+ *  
+ * 4.Shift register data clear in serial interface 
+ * 5.Display start line is set at display RAM address 0 
+ * 6.Column address counter is set at 0 
+ * 7.Normal scan direction of the COM outputs 
+ * 8.Contrast control register is set at 7Fh 
+ * 9.Normal display mode (Equivalent to A4h command)
+ */ 
+
+    // make sure that 
+    // display has not shift
+    // even without power on reset
+    oled.command(0x22);
+    oled.command(0x00);
+    oled.command(0x07);
+
+    // reduce brightness to minimum 
+    oled.command(0x81);
+    oled.command(0x01);
 }
 
 void UExtOled::process_asap() {}
@@ -82,11 +106,22 @@ void UExtOled::process_1s() {
 
     oled.drawRect(52, 2, 18, 9, 1);     // battery shape
     oled.drawRect(69, 3, 3, 7, 1);      // battery terminal
-    oled.drawRect(54, 4, 2, 5, 1);      // bar 1
-    oled.drawRect(57, 4, 2, 5, 1);      // bar 2
-    oled.drawRect(60, 4, 2, 5, 1);      // bar 3
-    oled.drawRect(63, 4, 2, 5, 1);      // bar 4
-    oled.drawRect(66, 4, 2, 5, 1);      // bar 5
+    
+    if (charger.soc >= 20) {
+        oled.drawRect(54, 4, 2, 5, 1);      // bar 1
+    }
+    if (charger.soc >= 40) {
+        oled.drawRect(57, 4, 2, 5, 1);      // bar 2
+    }
+    if (charger.soc >= 60) {
+        oled.drawRect(60, 4, 2, 5, 1);      // bar 3
+    }
+    if (charger.soc >= 80) {
+        oled.drawRect(63, 4, 2, 5, 1);      // bar 4
+    }
+    if (charger.soc >= 95) {
+        oled.drawRect(66, 4, 2, 5, 1);      // bar 5
+    }
 
     // solar panel data
 #ifdef CHARGER_TYPE_PWM
@@ -126,11 +161,24 @@ void UExtOled::process_1s() {
     oled.printf("Tot +%4.1fkWh -%4.1fkWh", dev_stat.solar_in_total_Wh / 1000.0, fabs(dev_stat.load_out_total_Wh) / 1000.0);
 
     oled.setTextCursor(0, 56);
+
 #ifdef CHARGER_TYPE_PWM
-    oled.printf("T %.0fC PWM %.0f%% SOC %d%%", charger.bat_temperature, pwm_switch_get_duty_cycle() * 100.0, charger.soc);
+    bool pwm_enabled = pwm_switch.active()();
+    float duty_cycle = pwm_switch.get_duty_cycle();
 #else
-    oled.printf("T %.0fC PWM %.0f%% SOC %d%%", charger.bat_temperature, half_bridge_get_duty_cycle() * 100.0, charger.soc);
-#endif
+    bool pwm_enabled = half_bridge_enabled();
+    float duty_cycle = half_bridge_get_duty_cycle();
+#endif 
+
+    float temp = charger.ext_temp_sensor ? charger.bat_temperature:dev_stat.internal_temp;
+    char tC = charger.ext_temp_sensor ? 'T' : 't';
+
+    if (pwm_enabled == true) {
+        oled.printf("%c %.0fC PWM %.0f%% SOC %d%%", tC, temp, duty_cycle * 100.0, charger.soc);
+    } 
+    else {
+        oled.printf("%c %.0fC PWM OFF SOC %d%%", tC, temp, charger.soc);
+    }
 
     oled.display();
 }


### PR DESCRIPTION
- OLED display can be set to extend life of OLED
- OLED display correctly initialized at MCU restart even without power off
  Sometimes the OLED display displays all content shifted if the MCU is
  reset without cutting the power to the display (i.e. without display reset).
- SOC is display in battery symbol showing 0 to 5 bars
- Internal temperature is displayed if no external sensor is detected (t)
- PWM value displays as "OFF" if the PWM/halfbridge is not active