### PR TITLE
Overvoltage limit overflow fix

### DIFF
--- a/src/adc_dma.cpp
+++ b/src/adc_dma.cpp
@@ -81,8 +81,8 @@ static inline uint32_t adc_value(uint32_t channel)
  * Measured voltage for ADC channel after average
  * @param channel valid ADC channel pos ADC_POS_..., see adc_h.c
  * @param vcc reference voltage in millivolts
- * 
- * @return voltage in millivolts 
+ *
+ * @return voltage in millivolts
  */
 static inline float adc_voltage(uint32_t channel, int32_t vcc)
 {
@@ -92,8 +92,8 @@ static inline float adc_voltage(uint32_t channel, int32_t vcc)
  * Measured current/voltage for ADC channel after average and scaling
  * @param channel valid ADC channel pos ADC_POS_..., see adc_h.c
  * @param vcc reference voltage in millivolts
- * 
- * @return scaled final value 
+ *
+ * @return scaled final value
  */
 static inline float adc_scaled(uint32_t channel, int32_t vcc, const float gain)
 {
@@ -108,7 +108,7 @@ static inline float ntc_temp(uint32_t channel, int32_t vcc)
 
     float v_temp = adc_voltage(channel, vcc);  // voltage read by ADC (mV)
     float rts = NTC_SERIES_RESISTOR * v_temp / (vcc - v_temp); // resistance of NTC (Ohm)
-    
+
     return 1.0/(1.0/(273.15+25) + 1.0/NTC_BETA_VALUE*log(rts/10000.0)) - 273.15; // °C
 
 }
@@ -230,7 +230,7 @@ void update_measurements()
 #ifdef PIN_ADC_TEMP_BAT
     // battery temperature calculation
     float bat_temp = ntc_temp(ADC_POS_TEMP_BAT, vcc);
-    
+
     if (bat_temp > -50) {
         // external sensor connected: take measured value
         charger.bat_temperature = bat_temp;
@@ -300,10 +300,10 @@ void adc_upper_alert_inhibit(int adc_pos, int timeout_ms)
     adc_alerts_upper[adc_pos].debounce_ms = -timeout_ms;
 }
 
-static uint16_t adc_get_alert_limit(float scale, float limit)
+uint16_t adc_get_alert_limit(float scale, float limit)
 {
-    const float adclimit = 0x0FFF; // 12 bits ADC resolution
-    const float limit_scaled = limit * scale; 
+    const float adclimit = (UINT16_MAX >> 4); // 12 bits ADC resolution
+    const float limit_scaled = limit * scale;
     // even if we have a higher voltage limit, we must limit it
     // to the max value the ADC will be able to deliver
     return (limit_scaled > adclimit ? 0x0FFF : (uint16_t)(limit_scaled)) << 4; 
@@ -313,7 +313,7 @@ static uint16_t adc_get_alert_limit(float scale, float limit)
 void adc_set_lv_alerts(float upper, float lower)
 {
     int vcc = VREFINT_VALUE * VREFINT_CAL / adc_value(ADC_POS_VREF_MCU);
-    float scale =  ((4096* 1000) / (ADC_GAIN_V_BAT)) / vcc;    
+    float scale =  ((4096* 1000) / (ADC_GAIN_V_BAT)) / vcc;
 
     // LV side (battery) overvoltage alert
     adc_alerts_upper[ADC_POS_V_BAT].limit = adc_get_alert_limit(scale, upper);
@@ -547,7 +547,7 @@ void clear_adc_filtered()
         // initialize also filtered values
     for (int i = 0; i < NUM_ADC_CH; i++) {
         adc_filtered[i] = 0;
-    }  
+    }
 }
 uint32_t get_adc_filtered(uint32_t channel)
 {

--- a/src/adc_dma.cpp
+++ b/src/adc_dma.cpp
@@ -149,7 +149,7 @@ void adc_update_value(unsigned int pos)
     // check upper alerts
     adc_alerts_upper[pos].debounce_ms++;
     if (adc_alerts_upper[pos].callback != NULL &&
-        adc_readings[pos] > adc_alerts_upper[pos].limit)
+        adc_readings[pos] >= adc_alerts_upper[pos].limit)
     {
         if (adc_alerts_upper[pos].debounce_ms > 1) {
             // create function pointer and call function
@@ -165,7 +165,7 @@ void adc_update_value(unsigned int pos)
     // same for lower alerts
     adc_alerts_lower[pos].debounce_ms++;
     if (adc_alerts_lower[pos].callback != NULL &&
-        adc_readings[pos] < adc_alerts_lower[pos].limit)
+        adc_readings[pos] <= adc_alerts_lower[pos].limit)
     {
         if (adc_alerts_lower[pos].debounce_ms > 1) {
             adc_alerts_lower[pos].callback();

--- a/src/bat_charger.cpp
+++ b/src/bat_charger.cpp
@@ -111,7 +111,7 @@ void battery_conf_init(BatConf *bat, BatType type, int num_cells, float nominal_
         case BAT_TYPE_NMC:
         case BAT_TYPE_NMC_HV:
             bat->topping_voltage = num_cells * ((type == BAT_TYPE_NMC_HV) ? 4.35 : 4.20);
-            bat->voltage_absolute_max = num_cells * (bat->topping_voltage + 0.05);
+            bat->voltage_absolute_max = bat->topping_voltage + num_cells * 0.05;
             bat->voltage_recharge = num_cells * 3.9;
 
             bat->voltage_load_disconnect = num_cells * 3.3;
@@ -191,7 +191,7 @@ void battery_conf_overwrite(BatConf *source, BatConf *destination, Charger *char
     destination->voltage_absolute_min           = source->voltage_absolute_min;
     destination->charge_current_max             = source->charge_current_max;
     destination->topping_current_cutoff         = source->topping_current_cutoff;
-    destination->topping_duration             = source->topping_duration;
+    destination->topping_duration               = source->topping_duration;
     destination->trickle_enabled                = source->trickle_enabled;
     destination->trickle_voltage                = source->trickle_voltage;
     destination->trickle_recharge_time          = source->trickle_recharge_time;

--- a/test/adc_dma_stub.h
+++ b/test/adc_dma_stub.h
@@ -34,4 +34,6 @@ void prepare_adc_readings(AdcValues values);
 void prepare_adc_filtered();
 void clear_adc_filtered();
 uint32_t get_adc_filtered(uint32_t channel);
+uint16_t adc_get_alert_limit(float scale, float limit);
+
 #endif

--- a/test/tests_adc_dma.cpp
+++ b/test/tests_adc_dma.cpp
@@ -5,10 +5,9 @@
 
 #include "main.h"
 
-static AdcValues adcval;
+#include <stdint.h>
 
-extern uint32_t adc_filtered[NUM_ADC_CH];
-extern AdcAlert adc_alerts[NUM_ADC_CH];
+static AdcValues adcval;
 
 // testing only for 2 values
 void check_filtering()
@@ -123,6 +122,13 @@ void adc_alert_overvoltage_triggering()
     TEST_ASSERT_EQUAL(false, dev_stat.has_error(ERR_BAT_OVERVOLTAGE));
 }
 
+void adc_alert_overflow_prevention()
+{
+    // try to set an alert that overflows the 12-bit ADC resolution
+    uint16_t limit = adc_get_alert_limit(1, 4097);
+    TEST_ASSERT_EQUAL_HEX((uint16_t)(UINT16_MAX << 4), limit);
+}
+
 /** ADC conversion test
  *
  * Purpose: Check if raw data from 2 voltage and 2 current measurements are converted
@@ -154,6 +160,7 @@ void adc_tests()
 
     RUN_TEST(adc_alert_undervoltage_triggering);
     RUN_TEST(adc_alert_overvoltage_triggering);
+    RUN_TEST(adc_alert_overflow_prevention);
 
     UNITY_END();
 }


### PR DESCRIPTION
the bat config calculation did calculate the absolute max voltage
too high for NMC/NMC_HV, it was doing an unnecessary multiplication.
This triggered an issue in the voltage limit set code, which did not
handle the overflow of the 16bit limit value properly.

Both are fixed now. We limit the limit value to what the ADC is able
to deliver, so that we detect overvoltage for sure, even if the setting
is out of ADC range.