### PR TITLE
Improve full charge detection and topping control

### DIFF
--- a/src/bat_charger.h
+++ b/src/bat_charger.h
@@ -251,16 +251,16 @@ public:
     uint16_t soc = 100;             ///< State of Charge (%)
     uint16_t soh = 100;             ///< State of Health (%)
 
-    time_t time_state_changed;         ///< Timestamp of last state change
-    time_t time_voltage_limit_reached; ///< Last time the CV limit was reached
+    time_t time_state_changed;          ///< Timestamp of last state change
+    time_t time_target_voltage_reached; ///< Last time the CV limit was reached
+
+    int target_voltage_timer;       ///< Counts the number of seconds during which the target
+                                    ///< voltage of current charging phase was reached.
 
     time_t time_last_equalization;  ///< Timestamp after finish of last equalization charge
     int deep_dis_last_equalization; ///< Deep discharge counter value after last equalization
 
     bool full;                      ///< Flag to indicate if battery was fully charged
-    bool first_full_charge_reached = false;
-                                    //< Set to true if battery was fully charged at least once
-                                    ///< (necessary for proper capacity estimation)
 
     /** Detect if two batteries are connected in series (12V/24V auto-detection)
      */


### PR DESCRIPTION
The battery is only full if the topping voltage is still reached AND the
current is below cut-off threshold at the same time. This was not always
detected correctly with previous 2s target voltage monitoring interval.

In addition to that, a new timer was introduced to count seconds at target
voltage and improve full charge detection due to timeout.

This PR also removes the `first_full_charge_reached` flag, as it is unnecessary. If the `useable_capacity == 0`, we know that this value hasn't been updated before, so must have been the first full charge and discharge cycle.

And we are also fixing a bug in equalization voltage calculation (number of batteries was not considered).