### PR TITLE
ADC-DMA for STM32G431 in the Zephyr framework

### DIFF
--- a/boards/arm/mppt_2420_hpx/Kconfig.board
+++ b/boards/arm/mppt_2420_hpx/Kconfig.board
@@ -4,3 +4,19 @@
 config BOARD_MPPT_2420_HPX
 	bool "Libre Solar MPPT 2420 HPX"
 	depends on SOC_STM32G431XX
+
+if ADC_STM32
+
+config ADC_1
+	prompt "ADC1"
+	default y
+	help
+	  Enable ADC1
+
+config ADC_2
+	prompt "ADC2"
+	default y
+	help
+	  Enable ADC2
+
+endif # ADC_STM32

--- a/boards/arm/mppt_2420_hpx/mppt_2420_hpx.dts
+++ b/boards/arm/mppt_2420_hpx/mppt_2420_hpx.dts
@@ -129,3 +129,7 @@
 &adc1 {
 	status = "okay";
 };
+
+&adc2 {
+	status = "okay";
+};

--- a/boards/arm/mppt_2420_hpx/pinmux.c
+++ b/boards/arm/mppt_2420_hpx/pinmux.c
@@ -64,6 +64,9 @@ static const struct pin_config pinconf[] = {
 	{STM32_PIN_PA11, STM32G4X_PINMUX_FUNC_PA11_USB_DM},
 	{STM32_PIN_PA12, STM32G4X_PINMUX_FUNC_PA12_USB_DP},
 #endif	/* CONFIG_USB_DC_STM32 */
+#ifdef CONFIG_ADC_2
+    {STM32_PIN_PA4, STM32G4X_PINMUX_FUNC_PA4_ADC2_IN0},
+#endif  /* CONFIG_ADC_2 */
 };
 
 static int pinmux_stm32_init(struct device *port)

--- a/src/daq_zephyr.c
+++ b/src/daq_zephyr.c
@@ -81,6 +81,8 @@ static const u32_t table_seq_len[] = {
 };
 #endif /* !STM32F0X && !STM32L0X */
 
+#define DT_ADC_2_NAME "ADC_2"
+
 // for ADC and DMA
 extern uint16_t adc_readings[];
 

--- a/src/daq_zephyr.c
+++ b/src/daq_zephyr.c
@@ -31,6 +31,7 @@
 #include <stm32g4xx_ll_system.h>
 #include <stm32g4xx_ll_dac.h>
 #include <stm32g4xx_ll_dma.h>
+#include <stm32g4xx_ll_bus.h>
 #endif
 
 #include "pcb.h"
@@ -124,7 +125,10 @@ static void adc_setup()
         .channel_id = LL_ADC_CHANNEL_0,
         .differential = 0
     };
-    adc_channel_setup(dev_adc, &channel_cfg);
+    int ret = adc_channel_setup(dev_adc, &channel_cfg);
+    if(ret){
+        printk("ADC channel setup error.. \n");
+    }
 
     // The following configuration necessary for DMA is not yet possible with Zephyr driver,
     // so we need to use STM LL interface directly
@@ -143,7 +147,7 @@ static void adc_setup()
 #endif
 
     LL_ADC_SetDataAlignment(ADC1, LL_ADC_DATA_ALIGN_LEFT);
-	LL_ADC_SetResolution(ADC1, LL_ADC_RESOLUTION_12B);
+    LL_ADC_SetResolution(ADC1, LL_ADC_RESOLUTION_12B);
     LL_ADC_REG_SetOverrun(ADC1, LL_ADC_REG_OVR_DATA_OVERWRITTEN);
 
     // Enable DMA transfer on ADC and circular mode
@@ -169,6 +173,11 @@ static void DMA1_Channel1_IRQHandler(void *args)
 static void dma_setup()
 {
     LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_DMA1);
+
+#if defined(CONFIG_SOC_SERIES_STM32G4X)
+    LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_DMAMUX1);
+    LL_DMA_SetPeriphRequest(DMA1, LL_DMA_CHANNEL_1, LL_DMAMUX_REQ_ADC1);
+#endif //CONFIG_SOC_SERIES_STM32G4X
 
     LL_DMA_ConfigAddresses(DMA1, LL_DMA_CHANNEL_1,
         LL_ADC_DMA_GetRegAddr(ADC1, LL_ADC_DMA_REG_REGULAR_DATA),   // source address


### PR DESCRIPTION
What does this PR do?
ADC-DMA support for STM32G431 and ADC2 support for MPPT_2420_HPX in the Zephyr framework.
- Added additional clock setting for DMA. 
- DMAMUX enabled for setting DMA request for the DMA instance on the Channel x.
- DTS, Kconfig and pinmux configurations changed to support ADC2 in "mppt_2420_hpx" board.

What are the relevant tickets?
NA

Where should the reviewer start?
The file daq_zephyr.c

How should this be manually tested?
ADC values must be updated automatically by the DMA interrupt routine.

Any background context you want to provide?
To work with ADC2, stm32 adc driver macro in the file adc_stm32.c needs to be modified.