### PR TITLE
Configure custom data nodes

### DIFF
--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -29,6 +29,11 @@ config LIBRE_SOLAR_TYPE_ID
     help
       Numeric Libre Solar hardware type ID
 
+config CUSTOM_DATA_NODES_FILE
+    bool
+    default n
+    help
+      Use the custom made data_nodes file
 
 #
 # Visible (user-configurable) Kconfig symbols

--- a/src/data_nodes.cpp
+++ b/src/data_nodes.cpp
@@ -22,7 +22,7 @@
 
 // can be used to configure custom data objects in separate file instead
 // (e.g. data_nodes_custom.cpp)
-#ifndef CUSTOM_DATA_NODES_FILE
+#ifndef CONFIG_CUSTOM_DATA_NODES_FILE
 
 #include "thingset.h"
 #include "hardware.h"

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -12,6 +12,8 @@ add_definitions(-D__ZEPHYR__ -DDEBUG_PRINT_FLAGS=7)
 
 include_directories(../src)
 
+target_sources_if_kconfig(CONFIG_CUSTOM_DATA_NODES_FILE, app PRIVATE ../src/data_nodes_custom.cpp)
+
 target_sources(app PRIVATE
         ../src/bat_charger.cpp
         ../src/data_nodes.cpp


### PR DESCRIPTION
What does this PR do?
- Configurations for supporting custom data nodes. Use custom data nodes for build if they are defined.
- CONFIG_CUSTOM_DATA_NODES_FILE is now generated using Kconfig.
- Target sources to build data_nodes_custom.cpp is now based on the Kconfig definition.