### PR TITLE
Allow more generic firmware customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,36 @@ st-flash 1.5.1
 
 check the connection between the programmer (for example the ST-Link of the Nucleo board) and the charge controller.
 
+## Firmware customization
+
+This firmware is developed to allow easy customization for individual use-cases. Below options based on the Zephyr devicetree and Kconfig systems try to allow customization without changing any of the files tracked by git, so that a `git pull` does not lead to conflicts with local changes.
+
+### Hardware-specific changes
+
+In Zephyr, all hardware-specific configuration is described in the [devicetree](https://docs.zephyrproject.org/latest/guides/dts/index.html).
+
+The file `boards/arm/board_name/board_name.dts` contains the default devicetree specification (DTS) for a board. It is based on the DTS of the used MCU, which is included from the main Zephyr repository.
+
+In order to overwrite the default configuration, so-called overlays can be used. An overlay file can be specified via the west command line. If it is stored as `board_name.overlay` in the `zephyr` subfolder, it will be recognized automatically when building the firmware for that board (also with PlatformIO).
+
+In order to support older board versions (e.g. with changed pins), some overlays with appended version numbers are already existing as a template. Remove the version number (e.g. `_0v4`) to "activate" them.
+
+### Application firmware configuration
+
+For configuration of the application-specific features, Zephyr uses the [Kconfig system](https://docs.zephyrproject.org/latest/guides/kconfig/index.html).
+
+The configuration can be changed using `west build -t menuconfig` command or manually by changing the prj.conf file.
+
+Similar to DTS overlays, the Kconfig can also be customized for each board. Copy the default `prj.conf` to a file `prj_board_name.conf` to use this file instead of `prj.conf`. Please not that, in contrast to overlays, the board-specific Kconfig files are not **added** to the default `prj.conf`, but they **replace** the default configuration instead.
+
+### Custom functions (separate C/C++ files)
+
+If you want experiment with some completely new functions for the charge controller, new files should be stored in a subfolder `src/custom`.
+
+To add the files to the firmware build, create an own CMakeLists.txt in the folder and enable the Kconfig option `CONFIG_CUSTOMIZATION`.
+
+If you think the customization could be relevant for others, please consider sending a pull request. Integrating features into the upstream charge controller firmware guarantees that the feature stays up-to-date and that it will not accidentally break after changes in the original firmware.
+
 ## Bootloader Support (STM32L072 only)
 
 The custom linker script file STM32L072XZ.ld.link_script.ld needs to be updated before generating the application firmware binary. For each application, the flash start address and the maximum code size need to be updated in this file. Currently, the locations 0x08001000 and 0x08018000 are used for applications 1 & 2 respectively.

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -19,12 +19,6 @@ config LIBRE_SOLAR_TYPE_ID
     help
       Numeric Libre Solar hardware type ID
 
-config CUSTOM_DATA_NODES_FILE
-    bool
-    default n
-    help
-      Use the custom made data_nodes file
-
 #
 # Visible (user-configurable) Kconfig symbols
 #
@@ -183,3 +177,23 @@ config THINGSET_MAKER_PASSWORD
     default "maker456"
 
 endmenu
+
+
+menuconfig CUSTOMIZATION
+    bool "Firmware customization"
+    help
+      Activating this option allows to overwrite existing firmware functions
+      or add customizations independent of the master branch.
+      Custom implementations should be stored in the
+      src/custom subdirectory.
+
+if CUSTOMIZATION
+
+config CUSTOM_DATA_NODES_FILE
+    bool "Use custom data nodes file"
+    default n
+    help
+      Use a custom file instead of default data_nodes.cpp for
+      ThingSet configuration.
+
+endif

--- a/boards/Kconfig
+++ b/boards/Kconfig
@@ -5,16 +5,6 @@
 # Invisible (board-specific) Kconfig symbols
 #
 
-config HAS_LOAD_OUTPUT
-	bool
-	help
-	  PCB has a load output.
-
-config HAS_USB_PWR_OUTPUT
-	bool
-	help
-	  PCB has a USB power output.
-
 config CONTROL_FREQUENCY
 	int
 	default 10
@@ -116,7 +106,6 @@ choice
 
     config BAT_DEFAULT_TYPE_NMC_HV
         bool "NMC/Graphite High Voltage Li-ion, 3.7V nominal, 4.35 max"
-
 endchoice
 
 # values must match enum BatType in bat_charger.h
@@ -192,9 +181,5 @@ config THINGSET_MAKER_PASSWORD
     depends on EXT_THINGSET_SERIAL || EXT_THINGSET_CAN
     string "ThingSet maker password"
     default "maker456"
-
-config DEVICE_ID
-    int "Initial device ID for communication interfaces"
-    default 0
 
 endmenu

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -40,6 +40,12 @@ target_sources(app PRIVATE
         ../src/ext/can_msg_queue.cpp
 )
 
+# Using this option enables user-specific customization of the firmware. The
+# src/custom subfolder should have its own CMakeLists.txt file.
+if(${CONFIG_CUSTOMIZATION})
+        add_subdirectory(../src/custom build/custom)
+endif()
+
 add_subdirectory(../lib/thingset build/thingset)
 add_subdirectory(../lib/oled-display build/oled-display)
 #add_subdirectory_ifdef(CONFIG_EXT_OLED_DISPLAY ../lib/oled-display)


### PR DESCRIPTION
This commit adds a new Kconfig setting CONFIG_CUSTOMIZATION. If enabled, the
subdirectory src/custom is added to the build. It can contain an own
CMakeLists.txt file to add several different C/C++ files.

Readme has been updated to explain also DTS overlays and custom prj.conf files.