### PR TITLE
Count energy only when on

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,17 +138,23 @@ void control_thread()
 
             // energy + soc calculation must be called exactly once per second
             #if DT_COMPAT_DCDC
-            hv_terminal.energy_balance();
+            if  (dcdc.state != DCDC_STATE_OFF) {
+                hv_terminal.energy_balance();
+            }
             #endif
 
             #if DT_OUTPUTS_PWM_SWITCH_PRESENT
-            pwm_switch.energy_balance();
+            if (pwm_switch.active() == 1) {
+                pwm_switch.energy_balance();
+            }
             #endif
 
             lv_terminal.energy_balance();
 
             #if DT_OUTPUTS_LOAD_PRESENT
-            load.energy_balance();
+            if (load.state == 1) {
+                load.energy_balance();
+            }
             #endif
 
             dev_stat.update_energy();

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -25,4 +25,8 @@ int main()
     dcdc_tests();
     device_status_tests();
     load_tests();
+
+#ifdef CUSTOM_TESTS
+    custom_tests();
+#endif
 }

--- a/test/tests.h
+++ b/test/tests.h
@@ -20,3 +20,8 @@ void dcdc_tests();
 void device_status_tests();
 
 void load_tests();
+
+// activate this via build_flags in platformio.ini or custom.ini
+#ifdef CUSTOM_TESTS
+void custom_tests();
+#endif


### PR DESCRIPTION
This ensures that energy counters for hv, pwm switch and load outputs only update when those ports are active.

Doing this because when there is no current through the port, sometimes the energy counter in increased due to inaccuracies in the current counter. Particularly the load output counter could be used for billing purposes and inaccuracy is not ideal.

Edits were made in the control thread in main.cpp