### PR TITLE
Software watchdog for multiple threads

### DIFF
--- a/src/hardware.h
+++ b/src/hardware.h
@@ -15,6 +15,11 @@
 
 #include <stdint.h>
 
+struct sw_wdt_channel {
+	int64_t check_in_time;  ///< most recent check-in/feed-in time of a thread for sw_watchdog
+	int32_t timeout;        ///< timeout of corresponding thread for sw_watchdog
+};
+
 /**
  * Initialization of IWDG
  */
@@ -31,11 +36,6 @@ int watchdog_register(uint32_t timeout_ms);
  * Must be called after all channels have been registered
  */
 void watchdog_start();
-
-/**
- * Feed/kick the watchdog for given channel
- */
-void watchdog_feed(int channel_id);
 
 /** Timer for system control (main DC/DC or PWM control loop) is started
  *
@@ -55,5 +55,28 @@ void start_stm32_bootloader();
  * Reset device
  */
 void reset_device();
+
+/**
+ * Implements watchdog for multiple threads in software
+ */
+void sw_watchdog(struct k_timer *timer_id);
+
+/**
+ * Configure timer for software watchdog and
+ * configure actual watchdog
+ */
+void sw_watchdog_start();
+
+/**
+ * Register sw_watchdog
+ *
+ * @param timeout_ms Timeout in milliseconds
+ */
+int sw_watchdog_register(uint32_t timeout_ms);
+
+/**
+ * Feed/Check-in sw_watchdog for given thread
+ */
+void sw_watchdog_feed(int thread_id);
 
 #endif /* HARDWARE_H */

--- a/src/leds.cpp
+++ b/src/leds.cpp
@@ -5,8 +5,6 @@
  */
 
 #include "leds.h"
-
-#include "hardware.h"
 #include "board.h"
 
 static int led_states[NUM_LEDS];                // must be one of enum LedState
@@ -20,6 +18,7 @@ static bool charging = false;
 
 #include <zephyr.h>
 #include <drivers/gpio.h>
+#include "hardware.h"
 
 #define SLEEP_TIME_MS 	(1000/60/NUM_LEDS)		// 60 Hz
 
@@ -29,7 +28,8 @@ void leds_update_thread()
     int flicker_count = 0;
     bool flicker_state = 1;
     struct device *led_devs[NUM_LED_PINS];
-    int wdt_channel = watchdog_register(1000);
+
+    int wdt_channel = sw_watchdog_register(1000);
 
     for (int pin = 0; pin < NUM_LED_PINS; pin++) {
         led_devs[pin] = device_get_binding(led_ports[pin]);
@@ -38,7 +38,8 @@ void leds_update_thread()
     leds_init();
 
     while (1) {
-        watchdog_feed(wdt_channel);
+
+        sw_watchdog_feed(wdt_channel);
 
         // could be increased to value >NUM_LEDS to reduce on-time
         if (led_count >= NUM_LEDS) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,6 +74,7 @@ void main(void)
     // wait until all threads are spawned before activating the watchdog
     k_sleep(K_MSEC(2500));
     watchdog_start();
+    sw_watchdog_start();
 
     while (1) {
         charger.discharge_control(&bat_conf);
@@ -96,12 +97,13 @@ void main(void)
 void control_thread()
 {
     uint32_t last_call = 0;
-    int wdt_channel = watchdog_register(200);
+    int wdt_channel = sw_watchdog_register(200);
 
     while (1) {
+
         bool charging = false;
 
-        watchdog_feed(wdt_channel);
+        sw_watchdog_feed(wdt_channel);
 
         // convert ADC readings to meaningful measurement values
         daq_update();
@@ -174,13 +176,14 @@ void control_thread()
 void ext_mgr_thread()
 {
     uint32_t last_call = 0;
+    int wdt_channel = sw_watchdog_register(3000);
 
     // quite long watchdog timeout as we might be dealing with slow communication (e.g. modems
     // using AT commands via serial interface)
-    int wdt_channel = watchdog_register(3000);
 
     while (1) {
-        watchdog_feed(wdt_channel);
+
+        sw_watchdog_feed(wdt_channel);
 
         uint32_t now = k_uptime_get() / 1000;
         ext_mgr.process_asap();     // approx. every millisecond

--- a/zephyr/prj.conf
+++ b/zephyr/prj.conf
@@ -8,6 +8,8 @@ CONFIG_GPIO=y
 CONFIG_SERIAL=y
 CONFIG_I2C=y
 
+CONFIG_WDT_DISABLE_AT_BOOT=y
+
 # disable log by default to save memory for STM32F0 with little RAM
 CONFIG_LOG=y
 CONFIG_LOG_MINIMAL=y


### PR DESCRIPTION
A software watchdog has been implemented for multiple threads using a configured timer. In addition, actual watchdog has been used to monitor the software watchdog (if in case it fails).