### PR TITLE
STM32 bootloader triggering for STM32G4 and flash information via ThingSet

### DIFF
--- a/src/hardware.cpp
+++ b/src/hardware.cpp
@@ -20,6 +20,7 @@
 
 #include <power/reboot.h>
 #include <drivers/gpio.h>
+#include <drivers/flash.h>
 
 #include <logging/log.h>
 LOG_MODULE_REGISTER(hardware, CONFIG_HW_LOG_LEVEL);
@@ -27,13 +28,39 @@ LOG_MODULE_REGISTER(hardware, CONFIG_HW_LOG_LEVEL);
 void start_stm32_bootloader()
 {
 #if DT_NODE_EXISTS(DT_CHILD(DT_PATH(outputs), boot0))
-
     // pin is connected to BOOT0 via resistor and capacitor
     const struct device *dev = device_get_binding(DT_GPIO_LABEL(BOOT0_GPIO, gpios));
     gpio_pin_configure(dev, DT_GPIO_PIN(BOOT0_GPIO, gpios),
         DT_GPIO_FLAGS(BOOT0_GPIO, gpios) | GPIO_OUTPUT_ACTIVE);
 
     k_sleep(K_MSEC(100));   // wait for capacitor at BOOT0 pin to charge up
+    reset_device();
+#elif defined(CONFIG_SOC_SERIES_STM32G4X)
+    const struct device *flash = device_get_binding(DT_LABEL(DT_NODELABEL(flash0)));
+    flash_write_protection_set(flash, false);
+    // Set proper bits for booting the embedded bootloader (see table
+    // 5 in section 2.6.1 in document RM0440)
+
+    // nBOOT0: nBOOT0 option bit (equivalent to the BOOT0 pin)
+    // nSWBOOT0: 0: BOOT0 taken from the option bit nBOOT0
+    // nSWBOOT0: 1: BOOT0 taken from PB8/BOOT0 pin
+    // nBOOT1: Together with the BOOT0 pin, this bit selects boot mode
+    // from the Flash main memory, SRAM1 or the System memory.
+
+    FLASH->OPTR &= ~(FLASH_OPTR_nSWBOOT0 | FLASH_OPTR_nBOOT0);
+    FLASH->OPTR |= FLASH_OPTR_nBOOT1;
+
+    // Save the current registers in flash, to be reloaded at reset
+    FLASH->CR |= FLASH_CR_OPTSTRT;
+    k_sleep(K_MSEC(20));
+
+    // Reload the option registers from flash; should trigger a system
+    // reset.
+    FLASH->CR |= FLASH_CR_OBL_LAUNCH;
+
+    // If OBL_LAUNCH did not reset (it should), we'll force it by
+    // first locking back the flash registers and going for a reboot.
+    flash_write_protection_set(flash, true);
     reset_device();
 #endif
 }

--- a/test/soc.h
+++ b/test/soc.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) The Libre Solar Project Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Mock some functions from STM32 LL API or MCU registers
+ */
+
+#include <stdint.h>
+
+static inline uint32_t LL_GetFlashSize(void)
+{
+    return 128;
+}
+
+#define FLASH_PAGE_SIZE 2048


### PR DESCRIPTION
Adding functions required for firmware upgrade from ESP32 via serial.

This requires a change in the esp32-edge firmware as the flash information was moved to a dedicated `dfu` node in ThingSet.

One reason for moving it to a new node is that I'd like to use the `info` node for information that might be published to a remote server in order to track firmware version, etc. However, the flash size and flash page size is only interesting for a device that upgrades the firmware locally. Also it should not be possible to trigger the bootloader remotely as the device would get stuck afterwards. So if we move this to a dedicated node, all functions or values behind `info` and `exec` can be exposed to normal users.

Replaces PR #119 