### PR TITLE
Provide detailed log out for rejected battery configuration requests

### DIFF
--- a/app/src/bat_charger.cpp
+++ b/app/src/bat_charger.cpp
@@ -214,7 +214,10 @@ bool battery_conf_check(BatConf *bat_conf)
     // - capacity plausible
     //
 
-  	struct condition { std::function<bool()> func; const char* text;};
+    struct condition {
+        std::function<bool()> func; 
+        const char *text;
+    };
 
 	const condition conditions[] = {
 	{ .func = [bat_conf]() { return bat_conf->load_reconnect_voltage > (bat_conf->load_disconnect_voltage + 0.4); }, .text = "Load Reconnect Voltage must be higher than Load Disconnect Voltage + 0.4" },

--- a/app/src/bat_charger.cpp
+++ b/app/src/bat_charger.cpp
@@ -205,42 +205,39 @@ void battery_conf_init(BatConf *bat, int type, int num_cells, float nominal_capa
 }
 
 // checks settings in bat_conf for plausibility
+#include <functional>
 bool battery_conf_check(BatConf *bat_conf)
 {
     // things to check:
     // - load_disconnect/reconnect hysteresis makes sense?
     // - cutoff current not extremely low/high
     // - capacity plausible
+    //
 
-    LOG_DBG("battery_conf_check: %d %d %d %d %d %d %d",
-        bat_conf->load_reconnect_voltage > (bat_conf->load_disconnect_voltage + 0.6),
-        bat_conf->recharge_voltage < (bat_conf->topping_voltage - 0.4),
-        bat_conf->recharge_voltage > (bat_conf->load_disconnect_voltage + 1),
-        bat_conf->load_disconnect_voltage > (bat_conf->absolute_min_voltage + 0.4),
-        bat_conf->topping_cutoff_current < (bat_conf->nominal_capacity / 10.0),
-        bat_conf->topping_cutoff_current > 0.01,
-        (bat_conf->float_enabled == false ||
-            (bat_conf->float_voltage < bat_conf->topping_voltage &&
-             bat_conf->float_voltage > bat_conf->load_disconnect_voltage))
-    );
+  	struct condition { std::function<bool()> func; const char* text;};
 
-    return (
-        bat_conf->load_reconnect_voltage > (bat_conf->load_disconnect_voltage + 0.4) &&
-        bat_conf->recharge_voltage < (bat_conf->topping_voltage - 0.4) &&
-        bat_conf->recharge_voltage > (bat_conf->load_disconnect_voltage + 1) &&
-        bat_conf->load_disconnect_voltage > (bat_conf->absolute_min_voltage + 0.4) &&
-        // max. 10% drop
-        bat_conf->internal_resistance < bat_conf->load_disconnect_voltage * 0.1 /
-            DISCHARGE_CURRENT_MAX &&
-        // max. 3% loss
-        bat_conf->wire_resistance < bat_conf->topping_voltage * 0.03 / DISCHARGE_CURRENT_MAX &&
-        // C/10 or lower current cutoff allowed
-        bat_conf->topping_cutoff_current < (bat_conf->nominal_capacity / 10.0) &&
-        bat_conf->topping_cutoff_current > 0.01 &&
-        (bat_conf->float_enabled == false ||
-            (bat_conf->float_voltage < bat_conf->topping_voltage &&
-             bat_conf->float_voltage > bat_conf->load_disconnect_voltage))
-    );
+	const condition conditions[] = {
+	{ .func = [bat_conf]() { return bat_conf->load_reconnect_voltage > (bat_conf->load_disconnect_voltage + 0.4); }, .text = "Load Reconnect Voltage must be higher than Load Disconnect Voltage + 0.4" },
+	{ .func = [bat_conf]() { return bat_conf->recharge_voltage < (bat_conf->topping_voltage - 0.4); }, .text = "Recharge Voltage must be lower than Topping Voltage - 0.4" },
+	{ .func = [bat_conf]() { return bat_conf->recharge_voltage > (bat_conf->load_disconnect_voltage + 1);}, .text = "Recharge Voltage must be higher than Load Disconnect Voltage + 1.0" },
+	{ .func = [bat_conf]() { return bat_conf->load_disconnect_voltage > (bat_conf->absolute_min_voltage + 0.4);}, .text = "Load Disconnecct Voltage must be higher than Absolute Min Voltage + 0.4" },
+	{ .func = [bat_conf]() { return bat_conf->internal_resistance < bat_conf->load_disconnect_voltage * 0.1 / DISCHARGE_CURRENT_MAX;}, .text = "Internal Battery Resistance must not cause more than 10% drop at Max Discharge Current" },
+	{ .func = [bat_conf]() { return bat_conf->wire_resistance < bat_conf->topping_voltage * 0.03 / DISCHARGE_CURRENT_MAX;}, .text = "Wire Resistances must not cause more than 3% drop at Max Discharge Current" },
+	{ .func = [bat_conf]() { return bat_conf->topping_cutoff_current < (bat_conf->nominal_capacity / 10.0);}, .text = "Topping Cutoff Current must be less than 10% of Nominal Capacity (C/10)" },
+	{ .func = [bat_conf]() { return bat_conf->topping_cutoff_current > 0.01;}, .text = "Topping Cutoff Current must be higher than 0.01A" },
+	{ .func = [bat_conf]() { return bat_conf->float_enabled == false || bat_conf->float_voltage < bat_conf->topping_voltage;}, .text = "Floating Charge Voltage must be lower than Topping Voltage" },
+	{ .func = [bat_conf]() { return bat_conf->float_enabled == false || bat_conf->float_voltage > bat_conf->load_disconnect_voltage;}, .text = "Floating Charge Voltage must be higher than Topping Voltage" },
+   };
+
+    bool result = true;
+    for (auto cond: conditions)
+    {
+	    bool cond_res = cond.func();
+	    if (cond_res == false) { LOG_ERR("battery_conf_check: failed condition '%s'",cond.text); }
+	    result = result && cond_res;
+    }
+
+    return result;
 }
 
 void battery_conf_overwrite(BatConf *source, BatConf *destination, Charger *charger)

--- a/app/src/ext/can.cpp
+++ b/app/src/ext/can.cpp
@@ -152,7 +152,7 @@ const struct zcan_filter ctrl_filter = {
     .rtr_mask = 1
 };
 
-void can_pub_isr(uint32_t err_flags, void *arg)
+void can_pub_isr(int error, void *arg)
 {
 	// Do nothing. Publication messages are fire and forget.
 }

--- a/app/src/pwm_switch.h
+++ b/app/src/pwm_switch.h
@@ -113,13 +113,59 @@ public:
 extern "C" {
 #endif
 
+/**
+ * Read the currently set duty cycle
+ *
+ * @returns Duty cycle between 0.0 and 1.0
+ */
 float pwm_signal_get_duty_cycle();
+
+/**
+ * Set the duty cycle of the PWM signal
+ *
+ * @param duty Duty cycle between 0.0 and 1.0
+ */
 void pwm_signal_set_duty_cycle(float duty);
+
+/**
+ * Change raw timer capture/compare register by defined step
+ *
+ * @param delta Steps to be added/substracted from current CCR value
+ */
 void pwm_signal_duty_cycle_step(int delta);
+
+/**
+ * Initiatializes the registers to generate the PWM signal and sets duty
+ * cycle limits
+ *
+ * @param freq_Hz Switching frequency in Hz
+*/
 void pwm_signal_init_registers(int freq_Hz);
+
+/**
+ * Start the PWM generation
+ *
+ * @param duty Duty cycle between 0.0 and 1.0
+ */
 void pwm_signal_start(float pwm_duty);
+
+/**
+ * Stop the PWM generation
+ */
 void pwm_signal_stop();
+
+/**
+ * Check if the PWM pin voltage level is high (on-state)
+ *
+ * @returns true if pin is high, false if pin is low
+ */
 bool pwm_signal_high();
+
+/**
+ * Check if the PWM generation is active
+ *
+ * @returns true if PWM signal generation is active
+ */
 bool pwm_active();
 
 #ifdef __cplusplus

--- a/docs/src/overview/features.rst
+++ b/docs/src/overview/features.rst
@@ -1,2 +1,25 @@
 Features
 ========
+
+- Running on `Zephyr RTOS`_
+
+- STM32F0, STM32L0 and STM32G4 series MCUs
+
+- Different battery types supported (lead-acid, Li-ion, LiFePO4)
+
+- Maximum power point tracking (MPPT) algorithm based on Perturb and Observe (P&O)
+
+- PWM solar input (for certain hardware)
+
+- Load output with deep-discharge protection
+
+- Monitoring and configuration using the `ThingSet`_ protocol (mapping to MQTT, CoAP and HTTP
+  possible)
+
+  - Serial interface
+  - CAN bus
+
+- OLED display support
+
+.. _Zephyr RTOS: https://docs.zephyrproject.org
+.. _ThingSet: https://thingset.io


### PR DESCRIPTION
It also gets rid of the duplication of code between the debug output
and the actual return value calculation by folding both into the same
loop.

Did this because it was quite hard to figure out what exactly caused rejection of my config changes.
It would be even better if this would be send back somehow on the thingset channel, 
but this is better than nothing.