### PR TITLE
Add Clang-Format file and apply it

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,32 @@
+# Format definition for Libre Solar firmware
+#
+# Use Clang-Format plugin in VS Code and add "editor.formatOnSave": true to settings
+
+# Generic format
+BasedOnStyle: LLVM
+UseTab: Never
+IndentWidth: 4
+TabWidth: 4
+ColumnLimit: 100
+AccessModifierOffset: -4
+
+# Indentation and alignment
+AllowShortEnumsOnASingleLine: false
+AllowShortIfStatementsOnASingleLine: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveMacros: true
+AlignEscapedNewlines: DontAlign
+BreakBeforeBinaryOperators: NonAssignment
+IndentCaseLabels: true
+
+# Braces
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterClass: true
+  AfterControlStatement: MultiLine
+  AfterEnum: true
+  AfterStruct: true
+  AfterFunction: true
+  BeforeElse: true
+  SplitEmptyFunction: false
+Cpp11BracedListStyle: false

--- a/app/src/bat_charger.cpp
+++ b/app/src/bat_charger.cpp
@@ -11,13 +11,13 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(bat_charger, CONFIG_BAT_LOG_LEVEL);
 
-#include <math.h>       // for fabs function
-#include <stdio.h>
 #include <functional>
+#include <math.h> // for fabs function
+#include <stdio.h>
 
 #include "board.h"
-#include "helper.h"
 #include "device_status.h"
+#include "helper.h"
 
 extern DeviceStatus dev_stat;
 extern LoadOutput load;
@@ -34,80 +34,78 @@ void battery_conf_init(BatConf *bat, int type, int num_cells, float nominal_capa
     bat->nominal_capacity = nominal_capacity;
 
     // 1C should be safe for all batteries
-    bat->charge_current_max    = bat->nominal_capacity;
+    bat->charge_current_max = bat->nominal_capacity;
     bat->discharge_current_max = bat->nominal_capacity;
 
-    bat->time_limit_recharge = 60;              // sec
-    bat->topping_duration    = 120*60;          // sec
+    bat->time_limit_recharge = 60;    // sec
+    bat->topping_duration = 120 * 60; // sec
 
-    bat->charge_temp_max    =  50;
-    bat->charge_temp_min    = -10;
-    bat->discharge_temp_max =  50;
+    bat->charge_temp_max = 50;
+    bat->charge_temp_min = -10;
+    bat->discharge_temp_max = 50;
     bat->discharge_temp_min = -10;
 
-    switch (type)
-    {
+    switch (type) {
         case BAT_TYPE_FLOODED:
         case BAT_TYPE_AGM:
         case BAT_TYPE_GEL:
-            bat->absolute_max_voltage    = static_cast<float>(num_cells) * 2.45F;
-            bat->topping_voltage         = static_cast<float>(num_cells) * 2.4F;
-            bat->recharge_voltage        = static_cast<float>(num_cells) * 2.2F;
+            bat->absolute_max_voltage = static_cast<float>(num_cells) * 2.45F;
+            bat->topping_voltage = static_cast<float>(num_cells) * 2.4F;
+            bat->recharge_voltage = static_cast<float>(num_cells) * 2.2F;
 
             // Cell-level thresholds based on EN 62509:2011 (both thresholds current-compensated)
             bat->load_disconnect_voltage = static_cast<float>(num_cells) * 1.95F;
-            bat->load_reconnect_voltage  = static_cast<float>(num_cells) * 2.10F;
+            bat->load_reconnect_voltage = static_cast<float>(num_cells) * 2.10F;
 
             // assumption: Battery selection matching charge controller
-            bat->internal_resistance     = static_cast<float>(num_cells) * (1.95F - 1.80F) /
-                DISCHARGE_CURRENT_MAX;
+            bat->internal_resistance =
+                static_cast<float>(num_cells) * (1.95F - 1.80F) / DISCHARGE_CURRENT_MAX;
 
-            bat->absolute_min_voltage    = static_cast<float>(num_cells) * 1.6F;
+            bat->absolute_min_voltage = static_cast<float>(num_cells) * 1.6F;
 
             // Voltages during idle (no charging/discharging current)
-            bat->ocv_full                = static_cast<float>(num_cells) *
-                ((type == BAT_TYPE_FLOODED) ? 2.10F : 2.15F);
-            bat->ocv_empty               = static_cast<float>(num_cells) * 1.90F;
+            bat->ocv_full =
+                static_cast<float>(num_cells) * ((type == BAT_TYPE_FLOODED) ? 2.10F : 2.15F);
+            bat->ocv_empty = static_cast<float>(num_cells) * 1.90F;
 
             // https://batteryuniversity.com/learn/article/charging_the_lead_acid_battery
-            bat->topping_cutoff_current  = bat->nominal_capacity * 0.04F;  // 3-5 % of C/1
+            bat->topping_cutoff_current = bat->nominal_capacity * 0.04F; // 3-5 % of C/1
 
-            bat->float_enabled         = true;
-            bat->float_recharge_time   = 30*60;
+            bat->float_enabled = true;
+            bat->float_recharge_time = 30 * 60;
             // Values as suggested in EN 62509:2011
-            bat->float_voltage         = static_cast<float>(num_cells) *
-                ((type == BAT_TYPE_FLOODED) ? 2.35F : 2.3F);
+            bat->float_voltage =
+                static_cast<float>(num_cells) * ((type == BAT_TYPE_FLOODED) ? 2.35F : 2.3F);
 
             // Enable for flooded batteries only, according to
             // https://discoverbattery.com/battery-101/equalizing-flooded-batteries-only
-            bat->equalization_enabled    = false;
+            bat->equalization_enabled = false;
             // Values as suggested in EN 62509:2011
-            bat->equalization_voltage    = static_cast<float>(num_cells) *
-                ((type == BAT_TYPE_FLOODED) ? 2.50F : 2.45F);
-            bat->equalization_duration   = 60*60;
+            bat->equalization_voltage =
+                static_cast<float>(num_cells) * ((type == BAT_TYPE_FLOODED) ? 2.50F : 2.45F);
+            bat->equalization_duration = 60 * 60;
             bat->equalization_current_limit = (1.0F / 7.0F) * bat->nominal_capacity;
             bat->equalization_trigger_days = 60;
             bat->equalization_trigger_deep_cycles = 10;
 
-            bat->temperature_compensation = -0.003F;     // -3 mV/°C/cell
+            bat->temperature_compensation = -0.003F; // -3 mV/°C/cell
             break;
 
         case BAT_TYPE_LFP:
-            bat->absolute_max_voltage    = static_cast<float>(num_cells) * 3.60F;
-            bat->topping_voltage         = static_cast<float>(num_cells) * 3.55F;    // CV voltage
-            bat->recharge_voltage        = static_cast<float>(num_cells) * 3.35F;
+            bat->absolute_max_voltage = static_cast<float>(num_cells) * 3.60F;
+            bat->topping_voltage = static_cast<float>(num_cells) * 3.55F; // CV voltage
+            bat->recharge_voltage = static_cast<float>(num_cells) * 3.35F;
 
             bat->load_disconnect_voltage = static_cast<float>(num_cells) * 3.00F;
-            bat->load_reconnect_voltage  = static_cast<float>(num_cells) * 3.15F;
+            bat->load_reconnect_voltage = static_cast<float>(num_cells) * 3.15F;
 
             // 5% voltage drop at max current
-            bat->internal_resistance    = bat->load_disconnect_voltage * 0.05F /
-                                          DISCHARGE_CURRENT_MAX;
-            bat->absolute_min_voltage   = static_cast<float>(num_cells) * 2.0F;
+            bat->internal_resistance = bat->load_disconnect_voltage * 0.05F / DISCHARGE_CURRENT_MAX;
+            bat->absolute_min_voltage = static_cast<float>(num_cells) * 2.0F;
 
             // will give really nonlinear SOC calculation because of flat OCV of LFP cells...
-            bat->ocv_full   = static_cast<float>(num_cells) * 3.4F;
-            bat->ocv_empty  = static_cast<float>(num_cells) * 3.0F;
+            bat->ocv_full = static_cast<float>(num_cells) * 3.4F;
+            bat->ocv_empty = static_cast<float>(num_cells) * 3.0F;
 
             // C/10 cut-off at end of CV phase by default
             bat->topping_cutoff_current = bat->nominal_capacity / 10;
@@ -120,26 +118,25 @@ void battery_conf_init(BatConf *bat, int type, int num_cells, float nominal_capa
 
         case BAT_TYPE_NMC:
         case BAT_TYPE_NMC_HV:
-            bat->topping_voltage         = static_cast<float>(num_cells) *
-                ((type == BAT_TYPE_NMC_HV) ? 4.35F : 4.20F);
-            bat->absolute_max_voltage    = bat->topping_voltage +
-                static_cast<float>(num_cells) * 0.05F;
-            bat->recharge_voltage        = static_cast<float>(num_cells) * 3.9F;
+            bat->topping_voltage =
+                static_cast<float>(num_cells) * ((type == BAT_TYPE_NMC_HV) ? 4.35F : 4.20F);
+            bat->absolute_max_voltage =
+                bat->topping_voltage + static_cast<float>(num_cells) * 0.05F;
+            bat->recharge_voltage = static_cast<float>(num_cells) * 3.9F;
 
             bat->load_disconnect_voltage = static_cast<float>(num_cells) * 3.3F;
-            bat->load_reconnect_voltage  = static_cast<float>(num_cells) * 3.6F;
+            bat->load_reconnect_voltage = static_cast<float>(num_cells) * 3.6F;
 
             // 5% voltage drop at max current
-            bat->internal_resistance     = bat->load_disconnect_voltage * 0.05F /
-                DISCHARGE_CURRENT_MAX;
+            bat->internal_resistance = bat->load_disconnect_voltage * 0.05F / DISCHARGE_CURRENT_MAX;
 
-            bat->absolute_min_voltage    = static_cast<float>(num_cells) * 2.5F;
+            bat->absolute_min_voltage = static_cast<float>(num_cells) * 2.5F;
 
-            bat->ocv_full                = static_cast<float>(num_cells) * 4.0F;
-            bat->ocv_empty               = static_cast<float>(num_cells) * 3.0F;
+            bat->ocv_full = static_cast<float>(num_cells) * 4.0F;
+            bat->ocv_empty = static_cast<float>(num_cells) * 3.0F;
 
             // C/10 cut-off at end of CV phase by default
-            bat->topping_cutoff_current  = bat->nominal_capacity / 10;
+            bat->topping_cutoff_current = bat->nominal_capacity / 10;
 
             bat->float_enabled = false;
             bat->equalization_enabled = false;
@@ -149,53 +146,58 @@ void battery_conf_init(BatConf *bat, int type, int num_cells, float nominal_capa
 
         case BAT_TYPE_CUSTOM:
 #ifdef CONFIG_BAT_TYPE_CUSTOM
-            bat->absolute_max_voltage = 0.001F *
-                static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_ABS_MAX_VOLTAGE_MV);
+            bat->absolute_max_voltage =
+                0.001F * static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_ABS_MAX_VOLTAGE_MV);
 
-            bat->topping_voltage = 0.001F *
-                static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_TOPPING_VOLTAGE_MV);
+            bat->topping_voltage =
+                0.001F * static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_TOPPING_VOLTAGE_MV);
 
-            bat->recharge_voltage = 0.001F *
-                static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_RECHARGE_VOLTAGE_MV);
+            bat->recharge_voltage =
+                0.001F * static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_RECHARGE_VOLTAGE_MV);
 
-            bat->load_disconnect_voltage = 0.001F *
-                static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_DISCONNECT_VOLTAGE_MV);
-            bat->load_reconnect_voltage = 0.001F *
-                static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_RECONNECT_VOLTAGE_MV);
+            bat->load_disconnect_voltage =
+                0.001F
+                * static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_DISCONNECT_VOLTAGE_MV);
+            bat->load_reconnect_voltage =
+                0.001F
+                * static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_RECONNECT_VOLTAGE_MV);
 
-            bat->internal_resistance = 0.001F *
-                static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_INTERNAL_RESISTANCE_MOHM);
+            bat->internal_resistance =
+                0.001F
+                * static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_INTERNAL_RESISTANCE_MOHM);
 
-            bat->absolute_min_voltage = 0.001F *
-                static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_ABS_MIN_VOLTAGE_MV);
+            bat->absolute_min_voltage =
+                0.001F * static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_ABS_MIN_VOLTAGE_MV);
 
             // Voltages during idle (no charging/discharging current)
-            bat->ocv_full = 0.001F *
-                static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_OCV_FULL_MV);
-            bat->ocv_empty = 0.001F *
-                static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_OCV_EMPTY_MV);
+            bat->ocv_full =
+                0.001F * static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_OCV_FULL_MV);
+            bat->ocv_empty =
+                0.001F * static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_OCV_EMPTY_MV);
 
             // https://batteryuniversity.com/learn/article/charging_the_lead_acid_battery
-            bat->topping_cutoff_current = bat->nominal_capacity * 0.04F;  // 3-5 % of C/1
+            bat->topping_cutoff_current = bat->nominal_capacity * 0.04F; // 3-5 % of C/1
 
             bat->float_enabled = IS_ENABLED(CONFIG_CELL_FLOAT);
             bat->float_recharge_time = CONFIG_CELL_FLOAT_RECHARGE_TIME;
-            bat->float_voltage = 0.001F *
-                static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_FLOAT_VOLTAGE_MV);
+            bat->float_voltage =
+                0.001F * static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_FLOAT_VOLTAGE_MV);
 
             bat->equalization_enabled = IS_ENABLED(CONFIG_CELL_EQUALIZATION);
-            bat->equalization_voltage = 0.001F *
-                static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_EQUALIZATION_VOLTAGE_MV);
+            bat->equalization_voltage =
+                0.001F
+                * static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_EQUALIZATION_VOLTAGE_MV);
             bat->equalization_duration = CONFIG_CELL_EQUALIZATION_DURATION;
             bat->equalization_current_limit = (1.0F / 7.0F) * bat->nominal_capacity;
             bat->equalization_trigger_days = CONFIG_CELL_EQUALIZATION_TRIGGER_DAYS;
             bat->equalization_trigger_deep_cycles = CONFIG_CELL_EQUALIZATION_TRIGGER_DEEP_CYCLES;
 
-            bat->temperature_compensation = 0.001F *
-                static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_TEMP_COMPENSATION_MV_K);
+            bat->temperature_compensation =
+                0.001F
+                * static_cast<float>(CONFIG_BAT_NUM_CELLS * CONFIG_CELL_TEMP_COMPENSATION_MV_K);
 
-            bat->charge_temp_max    = CONFIG_BAT_CHARGE_TEMP_MAX;
-            bat->charge_temp_min    = CONFIG_BAT_CHARGE_TEMP_MIN;
+            bat->charge_temp_max = CONFIG_BAT_CHARGE_TEMP_MAX;
+            bat->charge_temp_min = CONFIG_BAT_CHARGE_TEMP_MIN;
             bat->discharge_temp_max = CONFIG_BAT_DISCHARGE_TEMP_MAX;
             bat->discharge_temp_min = CONFIG_BAT_DISCHARGE_TEMP_MIN;
 #else
@@ -214,65 +216,66 @@ bool battery_conf_check(BatConf *bat_conf)
     // - capacity plausible
     //
 
-    struct condition {
+    struct condition
+    {
         std::function<bool()> func;
         const char *text;
     };
 
     const condition conditions[] = {
-        {.func =
-             [bat_conf]() {
-                 return bat_conf->load_reconnect_voltage >
-                        (bat_conf->load_disconnect_voltage + 0.4);
-             },
-         .text = "Load Reconnect Voltage must be higher than Load Disconnect Voltage + 0.4"},
-        {.func =
-             [bat_conf]() {
-                 return bat_conf->recharge_voltage < (bat_conf->topping_voltage - 0.4);
-             },
-         .text = "Recharge Voltage must be lower than Topping Voltage - 0.4"},
-        {.func =
-             [bat_conf]() {
-                 return bat_conf->recharge_voltage > (bat_conf->load_disconnect_voltage + 1);
-             },
-         .text = "Recharge Voltage must be higher than Load Disconnect Voltage + 1.0"},
-        {.func =
-             [bat_conf]() {
-                 return bat_conf->load_disconnect_voltage > (bat_conf->absolute_min_voltage + 0.4);
-             },
-         .text = "Load Disconnecct Voltage must be higher than Absolute Min Voltage + 0.4"},
-        {.func =
-             [bat_conf]() {
-                 return bat_conf->internal_resistance <
-                        bat_conf->load_disconnect_voltage * 0.1 / DISCHARGE_CURRENT_MAX;
-             },
-         .text = "Internal Battery Resistance must not cause more than 10% drop at Max Discharge "
-                 "Current"},
-        {.func =
-             [bat_conf]() {
-                 return bat_conf->wire_resistance <
-                        bat_conf->topping_voltage * 0.03 / DISCHARGE_CURRENT_MAX;
-             },
-         .text = "Wire Resistances must not cause more than 3% drop at Max Discharge Current"},
-        {.func =
-             [bat_conf]() {
-                 return bat_conf->topping_cutoff_current < (bat_conf->nominal_capacity / 10.0);
-             },
-         .text = "Topping Cutoff Current must be less than 10% of Nominal Capacity (C/10)"},
-        {.func = [bat_conf]() { return bat_conf->topping_cutoff_current > 0.01; },
-         .text = "Topping Cutoff Current must be higher than 0.01A"},
-        {.func =
-             [bat_conf]() {
-                 return bat_conf->float_enabled == false ||
-                        bat_conf->float_voltage < bat_conf->topping_voltage;
-             },
-         .text = "Floating Charge Voltage must be lower than Topping Voltage"},
-        {.func =
-             [bat_conf]() {
-                 return bat_conf->float_enabled == false ||
-                        bat_conf->float_voltage > bat_conf->load_disconnect_voltage;
-             },
-         .text = "Floating Charge Voltage must be higher than Topping Voltage"},
+        { .func =
+              [bat_conf]() {
+                  return bat_conf->load_reconnect_voltage
+                         > (bat_conf->load_disconnect_voltage + 0.4);
+              },
+          .text = "Load Reconnect Voltage must be higher than Load Disconnect Voltage + 0.4" },
+        { .func =
+              [bat_conf]() {
+                  return bat_conf->recharge_voltage < (bat_conf->topping_voltage - 0.4);
+              },
+          .text = "Recharge Voltage must be lower than Topping Voltage - 0.4" },
+        { .func =
+              [bat_conf]() {
+                  return bat_conf->recharge_voltage > (bat_conf->load_disconnect_voltage + 1);
+              },
+          .text = "Recharge Voltage must be higher than Load Disconnect Voltage + 1.0" },
+        { .func =
+              [bat_conf]() {
+                  return bat_conf->load_disconnect_voltage > (bat_conf->absolute_min_voltage + 0.4);
+              },
+          .text = "Load Disconnecct Voltage must be higher than Absolute Min Voltage + 0.4" },
+        { .func =
+              [bat_conf]() {
+                  return bat_conf->internal_resistance
+                         < bat_conf->load_disconnect_voltage * 0.1 / DISCHARGE_CURRENT_MAX;
+              },
+          .text = "Internal Battery Resistance must not cause more than 10% drop at Max Discharge "
+                  "Current" },
+        { .func =
+              [bat_conf]() {
+                  return bat_conf->wire_resistance
+                         < bat_conf->topping_voltage * 0.03 / DISCHARGE_CURRENT_MAX;
+              },
+          .text = "Wire Resistances must not cause more than 3% drop at Max Discharge Current" },
+        { .func =
+              [bat_conf]() {
+                  return bat_conf->topping_cutoff_current < (bat_conf->nominal_capacity / 10.0);
+              },
+          .text = "Topping Cutoff Current must be less than 10% of Nominal Capacity (C/10)" },
+        { .func = [bat_conf]() { return bat_conf->topping_cutoff_current > 0.01; },
+          .text = "Topping Cutoff Current must be higher than 0.01A" },
+        { .func =
+              [bat_conf]() {
+                  return bat_conf->float_enabled == false
+                         || bat_conf->float_voltage < bat_conf->topping_voltage;
+              },
+          .text = "Floating Charge Voltage must be lower than Topping Voltage" },
+        { .func =
+              [bat_conf]() {
+                  return bat_conf->float_enabled == false
+                         || bat_conf->float_voltage > bat_conf->load_disconnect_voltage;
+              },
+          .text = "Floating Charge Voltage must be higher than Topping Voltage" },
     };
 
     bool result = true;
@@ -291,25 +294,25 @@ void battery_conf_overwrite(BatConf *source, BatConf *destination, Charger *char
 {
     // TODO: stop DC/DC
 
-    destination->topping_voltage                = source->topping_voltage;
-    destination->recharge_voltage               = source->recharge_voltage;
-    destination->load_reconnect_voltage         = source->load_reconnect_voltage;
-    destination->load_disconnect_voltage        = source->load_disconnect_voltage;
-    destination->absolute_max_voltage           = source->absolute_max_voltage;
-    destination->absolute_min_voltage           = source->absolute_min_voltage;
-    destination->charge_current_max             = source->charge_current_max;
-    destination->topping_cutoff_current         = source->topping_cutoff_current;
-    destination->topping_duration               = source->topping_duration;
-    destination->float_enabled                  = source->float_enabled;
-    destination->float_voltage                  = source->float_voltage;
-    destination->float_recharge_time            = source->float_recharge_time;
-    destination->charge_temp_max                = source->charge_temp_max;
-    destination->charge_temp_min                = source->charge_temp_min;
-    destination->discharge_temp_max             = source->discharge_temp_max;
-    destination->discharge_temp_min             = source->discharge_temp_min;
-    destination->temperature_compensation       = source->temperature_compensation;
-    destination->internal_resistance            = source->internal_resistance;
-    destination->wire_resistance                = source->wire_resistance;
+    destination->topping_voltage = source->topping_voltage;
+    destination->recharge_voltage = source->recharge_voltage;
+    destination->load_reconnect_voltage = source->load_reconnect_voltage;
+    destination->load_disconnect_voltage = source->load_disconnect_voltage;
+    destination->absolute_max_voltage = source->absolute_max_voltage;
+    destination->absolute_min_voltage = source->absolute_min_voltage;
+    destination->charge_current_max = source->charge_current_max;
+    destination->topping_cutoff_current = source->topping_cutoff_current;
+    destination->topping_duration = source->topping_duration;
+    destination->float_enabled = source->float_enabled;
+    destination->float_voltage = source->float_voltage;
+    destination->float_recharge_time = source->float_recharge_time;
+    destination->charge_temp_max = source->charge_temp_max;
+    destination->charge_temp_min = source->charge_temp_min;
+    destination->discharge_temp_max = source->discharge_temp_max;
+    destination->discharge_temp_min = source->discharge_temp_min;
+    destination->temperature_compensation = source->temperature_compensation;
+    destination->internal_resistance = source->internal_resistance;
+    destination->wire_resistance = source->wire_resistance;
 
     // reset Ah counter and SOH if battery nominal capacity was changed
     if (destination->nominal_capacity != source->nominal_capacity) {
@@ -328,33 +331,28 @@ void battery_conf_overwrite(BatConf *source, BatConf *destination, Charger *char
 
 bool battery_conf_changed(BatConf *a, BatConf *b)
 {
-    return (
-        a->topping_voltage                != b->topping_voltage ||
-        a->recharge_voltage               != b->recharge_voltage ||
-        a->load_reconnect_voltage         != b->load_reconnect_voltage ||
-        a->load_disconnect_voltage        != b->load_disconnect_voltage ||
-        a->absolute_max_voltage           != b->absolute_max_voltage ||
-        a->absolute_min_voltage           != b->absolute_min_voltage ||
-        a->charge_current_max             != b->charge_current_max ||
-        a->topping_cutoff_current         != b->topping_cutoff_current ||
-        a->topping_duration               != b->topping_duration ||
-        a->float_enabled                  != b->float_enabled ||
-        a->float_voltage                  != b->float_voltage ||
-        a->float_recharge_time            != b->float_recharge_time ||
-        a->charge_temp_max                != b->charge_temp_max ||
-        a->charge_temp_min                != b->charge_temp_min ||
-        a->discharge_temp_max             != b->discharge_temp_max ||
-        a->discharge_temp_min             != b->discharge_temp_min ||
-        a->temperature_compensation       != b->temperature_compensation ||
-        a->internal_resistance            != b->internal_resistance ||
-        a->wire_resistance                != b->wire_resistance
-    );
+    return (a->topping_voltage != b->topping_voltage || a->recharge_voltage != b->recharge_voltage
+            || a->load_reconnect_voltage != b->load_reconnect_voltage
+            || a->load_disconnect_voltage != b->load_disconnect_voltage
+            || a->absolute_max_voltage != b->absolute_max_voltage
+            || a->absolute_min_voltage != b->absolute_min_voltage
+            || a->charge_current_max != b->charge_current_max
+            || a->topping_cutoff_current != b->topping_cutoff_current
+            || a->topping_duration != b->topping_duration || a->float_enabled != b->float_enabled
+            || a->float_voltage != b->float_voltage
+            || a->float_recharge_time != b->float_recharge_time
+            || a->charge_temp_max != b->charge_temp_max || a->charge_temp_min != b->charge_temp_min
+            || a->discharge_temp_max != b->discharge_temp_max
+            || a->discharge_temp_min != b->discharge_temp_min
+            || a->temperature_compensation != b->temperature_compensation
+            || a->internal_resistance != b->internal_resistance
+            || a->wire_resistance != b->wire_resistance);
 }
 
 void Charger::detect_num_batteries(BatConf *bat) const
 {
-    if (port->bus->voltage > bat->absolute_min_voltage * 2 &&
-        port->bus->voltage < bat->absolute_max_voltage * 2)
+    if (port->bus->voltage > bat->absolute_min_voltage * 2
+        && port->bus->voltage < bat->absolute_max_voltage * 2)
     {
         port->bus->series_multiplier = 2;
         printf("Detected two batteries (total %.2f V max)\n", bat->topping_voltage * 2);
@@ -366,11 +364,11 @@ void Charger::detect_num_batteries(BatConf *bat) const
 
 void Charger::update_soc(BatConf *bat_conf)
 {
-    static int soc_filtered = 0;       // SOC / 100 for better filtering
+    static int soc_filtered = 0; // SOC / 100 for better filtering
 
     if (fabs(port->current) < 0.2) {
-        int soc_new = (int)((port->bus->voltage - bat_conf->ocv_empty) /
-                   (bat_conf->ocv_full - bat_conf->ocv_empty) * 10000.0);
+        int soc_new = (int)((port->bus->voltage - bat_conf->ocv_empty)
+                            / (bat_conf->ocv_full - bat_conf->ocv_empty) * 10000.0);
 
         if (soc_new > 500 && soc_filtered == 0) {
             // bypass filter during initialization
@@ -390,7 +388,7 @@ void Charger::update_soc(BatConf *bat_conf)
         soc = soc_filtered / 100;
     }
 
-    discharged_Ah += -port->current / 3600.0F;   // charged current is positive: change sign
+    discharged_Ah += -port->current / 3600.0F; // charged current is positive: change sign
 }
 
 void Charger::enter_state(int next_state)
@@ -402,8 +400,7 @@ void Charger::enter_state(int next_state)
 
 void Charger::discharge_control(BatConf *bat_conf)
 {
-#if BOARD_HAS_LOAD_OUTPUT || \
-    BOARD_HAS_USB_OUTPUT
+#if BOARD_HAS_LOAD_OUTPUT || BOARD_HAS_USB_OUTPUT
 
     if (!empty) {
         // as we don't have a proper SOC estimation, we determine an empty battery by the main
@@ -418,9 +415,7 @@ void Charger::discharge_control(BatConf *bat_conf)
             }
             else {
                 // slowly adapt new measurements with low-pass filter
-                usable_capacity =
-                    0.8F * usable_capacity +
-                    0.2F * discharged_Ah;
+                usable_capacity = 0.8F * usable_capacity + 0.2F * discharged_Ah;
             }
 
             // simple SOH estimation
@@ -456,25 +451,22 @@ void Charger::discharge_control(BatConf *bat_conf)
     else {
         // discharging currently not allowed. should we allow it?
 
-        if (port->bus->voltage >=
-            port->bus->src_control_voltage(bat_conf->absolute_min_voltage + 0.1F))
-        {
+        if (port->bus->voltage
+            >= port->bus->src_control_voltage(bat_conf->absolute_min_voltage + 0.1F)) {
             dev_stat.clear_error(ERR_BAT_UNDERVOLTAGE);
         }
 
-        if (bat_temperature < bat_conf->discharge_temp_max - 1 &&
-            bat_temperature > bat_conf->discharge_temp_min + 1)
+        if (bat_temperature < bat_conf->discharge_temp_max - 1
+            && bat_temperature > bat_conf->discharge_temp_min + 1)
         {
             dev_stat.clear_error(ERR_BAT_DIS_OVERTEMP | ERR_BAT_DIS_UNDERTEMP);
         }
 
-        if (!dev_stat.has_error(
-            ERR_BAT_UNDERVOLTAGE | ERR_BAT_DIS_OVERTEMP | ERR_BAT_DIS_UNDERTEMP))
-        {
+        if (!dev_stat.has_error(ERR_BAT_UNDERVOLTAGE | ERR_BAT_DIS_OVERTEMP
+                                | ERR_BAT_DIS_UNDERTEMP)) {
             // discharge current is stored as absolute value in bat_conf, but defined
             // as negative current for power port
             port->neg_current_limit = -bat_conf->discharge_current_max;
-
         }
     }
 #endif
@@ -494,9 +486,9 @@ void Charger::charge_control(BatConf *bat_conf)
         enter_state(CHG_STATE_IDLE);
     }
 
-    if (dev_stat.has_error(ERR_BAT_OVERVOLTAGE) &&
-        port->bus->voltage < (bat_conf->absolute_max_voltage - 0.5F) *
-                             port->bus->series_multiplier)
+    if (dev_stat.has_error(ERR_BAT_OVERVOLTAGE)
+        && port->bus->voltage
+               < (bat_conf->absolute_max_voltage - 0.5F) * port->bus->series_multiplier)
     {
         dev_stat.clear_error(ERR_BAT_OVERVOLTAGE);
     }
@@ -508,18 +500,18 @@ void Charger::charge_control(BatConf *bat_conf)
     // state machine
     switch (state) {
         case CHG_STATE_IDLE: {
-            if ((time_state_changed == CHARGER_TIME_NEVER ||
-                    ((uptime() - time_state_changed) > bat_conf->time_limit_recharge &&
-                    port->bus->voltage < port->bus->sink_control_voltage(
-                        bat_conf->recharge_voltage))
-                )
-                && port->bus->voltage > port->bus->sink_control_voltage(
-                    bat_conf->absolute_min_voltage) // ToDo set error flag otherwise
+            if ((time_state_changed == CHARGER_TIME_NEVER
+                 || ((uptime() - time_state_changed) > bat_conf->time_limit_recharge
+                     && port->bus->voltage
+                            < port->bus->sink_control_voltage(bat_conf->recharge_voltage)))
+                && port->bus->voltage
+                       > port->bus->sink_control_voltage(bat_conf->absolute_min_voltage)
                 && bat_temperature < bat_conf->charge_temp_max - 1
                 && bat_temperature > bat_conf->charge_temp_min + 1)
             {
-                port->bus->sink_voltage_intercept = bat_conf->topping_voltage +
-                    bat_conf->temperature_compensation * (bat_temperature - 25);
+                port->bus->sink_voltage_intercept =
+                    bat_conf->topping_voltage
+                    + bat_conf->temperature_compensation * (bat_temperature - 25);
                 port->pos_current_limit = bat_conf->charge_current_max;
                 target_current_control = port->pos_current_limit;
                 full = false;
@@ -532,8 +524,9 @@ void Charger::charge_control(BatConf *bat_conf)
         }
         case CHG_STATE_BULK: {
             // continuously adjust voltage setting for temperature compensation
-            port->bus->sink_voltage_intercept = bat_conf->topping_voltage +
-                bat_conf->temperature_compensation * (bat_temperature - 25);
+            port->bus->sink_voltage_intercept =
+                bat_conf->topping_voltage
+                + bat_conf->temperature_compensation * (bat_temperature - 25);
 
             if (port->bus->voltage > port->bus->sink_control_voltage()) {
                 target_voltage_timer = 0;
@@ -543,8 +536,9 @@ void Charger::charge_control(BatConf *bat_conf)
         }
         case CHG_STATE_TOPPING: {
             // continuously adjust voltage setting for temperature compensation
-            port->bus->sink_voltage_intercept = bat_conf->topping_voltage +
-                bat_conf->temperature_compensation * (bat_temperature - 25);
+            port->bus->sink_voltage_intercept =
+                bat_conf->topping_voltage
+                + bat_conf->temperature_compensation * (bat_temperature - 25);
 
             // power sharing: multiple devices in parallel supply the same current
             target_current_control = port->current_filtered;
@@ -552,8 +546,8 @@ void Charger::charge_control(BatConf *bat_conf)
             if (port->bus->voltage_filtered >= port->bus->sink_control_voltage() - 0.05F) {
                 // battery is full if topping target voltage is still reached (i.e. sufficient
                 // solar power available) and time limit or cut-off current reached
-                if (port->current_filtered < bat_conf->topping_cutoff_current ||
-                    target_voltage_timer > bat_conf->topping_duration)
+                if (port->current_filtered < bat_conf->topping_cutoff_current
+                    || target_voltage_timer > bat_conf->topping_duration)
                 {
                     full = true;
                 }
@@ -567,21 +561,22 @@ void Charger::charge_control(BatConf *bat_conf)
 
             if (full) {
                 num_full_charges++;
-                discharged_Ah = 0;         // reset coulomb counter
+                discharged_Ah = 0; // reset coulomb counter
 
-                if (bat_conf->equalization_enabled && (
-                    (uptime() - time_last_equalization) / (24*60*60)
-                    >= bat_conf->equalization_trigger_days ||
-                    num_deep_discharges - deep_dis_last_equalization
-                    >= bat_conf->equalization_trigger_deep_cycles))
+                if (bat_conf->equalization_enabled
+                    && ((uptime() - time_last_equalization) / (24 * 60 * 60)
+                            >= bat_conf->equalization_trigger_days
+                        || num_deep_discharges - deep_dis_last_equalization
+                               >= bat_conf->equalization_trigger_deep_cycles))
                 {
                     port->bus->sink_voltage_intercept = bat_conf->equalization_voltage;
                     port->pos_current_limit = bat_conf->equalization_current_limit;
                     enter_state(CHG_STATE_EQUALIZATION);
                 }
                 else if (bat_conf->float_enabled) {
-                    port->bus->sink_voltage_intercept = bat_conf->float_voltage +
-                        bat_conf->temperature_compensation * (bat_temperature - 25);
+                    port->bus->sink_voltage_intercept =
+                        bat_conf->float_voltage
+                        + bat_conf->temperature_compensation * (bat_temperature - 25);
                     enter_state(CHG_STATE_FLOAT);
                 }
                 else {
@@ -593,8 +588,9 @@ void Charger::charge_control(BatConf *bat_conf)
         }
         case CHG_STATE_FLOAT: {
             // continuously adjust voltage setting for temperature compensation
-            port->bus->sink_voltage_intercept = bat_conf->float_voltage +
-                bat_conf->temperature_compensation * (bat_temperature - 25);
+            port->bus->sink_voltage_intercept =
+                bat_conf->float_voltage
+                + bat_conf->temperature_compensation * (bat_temperature - 25);
 
             target_current_control = port->current_filtered;
 
@@ -602,9 +598,9 @@ void Charger::charge_control(BatConf *bat_conf)
                 time_target_voltage_reached = uptime();
             }
 
-            if ((uptime() - time_target_voltage_reached > bat_conf->float_recharge_time) &&
-                port->bus->voltage_filtered < port->bus->sink_control_voltage(
-                    bat_conf->recharge_voltage))
+            if ((uptime() - time_target_voltage_reached > bat_conf->float_recharge_time)
+                && port->bus->voltage_filtered
+                       < port->bus->sink_control_voltage(bat_conf->recharge_voltage))
             {
                 // the battery was discharged: float voltage could not be reached anymore
                 port->pos_current_limit = bat_conf->charge_current_max;
@@ -617,23 +613,24 @@ void Charger::charge_control(BatConf *bat_conf)
         }
         case CHG_STATE_EQUALIZATION: {
             // continuously adjust voltage setting for temperature compensation
-            port->bus->sink_voltage_intercept = bat_conf->equalization_voltage +
-                bat_conf->temperature_compensation * (bat_temperature - 25);
+            port->bus->sink_voltage_intercept =
+                bat_conf->equalization_voltage
+                + bat_conf->temperature_compensation * (bat_temperature - 25);
 
             target_current_control = port->current_filtered;
 
             // current or time limit for equalization reached
-            if (uptime() - time_state_changed > bat_conf->equalization_duration)
-            {
+            if (uptime() - time_state_changed > bat_conf->equalization_duration) {
                 // reset triggers
                 time_last_equalization = uptime();
                 deep_dis_last_equalization = num_deep_discharges;
 
-                discharged_Ah = 0;         // reset coulomb counter again
+                discharged_Ah = 0; // reset coulomb counter again
 
                 if (bat_conf->float_enabled) {
-                    port->bus->sink_voltage_intercept = bat_conf->float_voltage +
-                        bat_conf->temperature_compensation * (bat_temperature - 25);
+                    port->bus->sink_voltage_intercept =
+                        bat_conf->float_voltage
+                        + bat_conf->temperature_compensation * (bat_temperature - 25);
                     enter_state(CHG_STATE_FLOAT);
                 }
                 else {
@@ -673,15 +670,15 @@ void Charger::init_terminal(BatConf *bat) const
      *
      * droop_res is multiplied with number of series connected batteries to calculate control
      * voltage, so we need to divide by number of batteries here for correction
-    */
-    port->bus->sink_droop_res = -bat->wire_resistance /
-        static_cast<float>(port->bus->series_multiplier);
+     */
+    port->bus->sink_droop_res =
+        -bat->wire_resistance / static_cast<float>(port->bus->series_multiplier);
 
     /*
      * In discharging direction also include battery internal resistance for current-compensation
      * of voltage setpoints
      */
-    port->bus->src_droop_res = -bat->wire_resistance /
-        static_cast<float>(port->bus->series_multiplier)
+    port->bus->src_droop_res =
+        -bat->wire_resistance / static_cast<float>(port->bus->series_multiplier)
         - bat->internal_resistance;
 }

--- a/app/src/bat_charger.h
+++ b/app/src/bat_charger.h
@@ -12,29 +12,30 @@
  * @brief Battery and charger configuration and functions
  */
 
-#include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <time.h>
 
 #include "power_port.h"
 
-#define CHARGER_TIME_NEVER      INT32_MIN
+#define CHARGER_TIME_NEVER INT32_MIN
 
 /**
  * Battery cell types
  */
-enum BatType {
+enum BatType
+{
     /*
      * IMPORTANT: make sure to adjust also boards/Kconfig if enum is changed here!
      */
-    BAT_TYPE_CUSTOM = 0,    ///< Custom battery type
-    BAT_TYPE_FLOODED,       ///< Old flooded (wet) lead-acid batteries
-    BAT_TYPE_GEL,           ///< VRLA gel batteries (maintainance-free)
-    BAT_TYPE_AGM,           ///< AGM batteries (maintainance-free)
-    BAT_TYPE_LFP,           ///< LiFePO4 Li-ion batteries (3.3V nominal)
-    BAT_TYPE_NMC,           ///< NMC/Graphite Li-ion batteries (3.7V nominal)
-    BAT_TYPE_NMC_HV         ///< NMC/Graphite High Voltage Li-ion batteries (3.7V nominal, 4.35 max)
+    BAT_TYPE_CUSTOM = 0, ///< Custom battery type
+    BAT_TYPE_FLOODED,    ///< Old flooded (wet) lead-acid batteries
+    BAT_TYPE_GEL,        ///< VRLA gel batteries (maintainance-free)
+    BAT_TYPE_AGM,        ///< AGM batteries (maintainance-free)
+    BAT_TYPE_LFP,        ///< LiFePO4 Li-ion batteries (3.3V nominal)
+    BAT_TYPE_NMC,        ///< NMC/Graphite Li-ion batteries (3.7V nominal)
+    BAT_TYPE_NMC_HV,     ///< NMC/Graphite High Voltage Li-ion batteries (3.7V nominal, 4.35 max)
 };
 
 /**
@@ -276,8 +277,8 @@ typedef struct
  * - https://en.wikipedia.org/wiki/IUoU_battery_charging
  * - https://batteryuniversity.com/learn/article/charging_the_lead_acid_battery
  */
-enum ChargerState {
-
+enum ChargerState
+{
     /**
      * Idle
      *
@@ -331,7 +332,7 @@ enum ChargerState {
      * higher priority on the CAN bus. The device goes in current control modes and tries to
      * match the current of the other controller.
      */
-    CHG_STATE_FOLLOWER
+    CHG_STATE_FOLLOWER,
 };
 
 /**
@@ -340,8 +341,7 @@ enum ChargerState {
 class Charger
 {
 public:
-    Charger(PowerPort *pwr_port):
-        port(pwr_port) {};
+    Charger(PowerPort *pwr_port) : port(pwr_port){};
 
     PowerPort *port;
 

--- a/app/src/board.h
+++ b/app/src/board.h
@@ -15,11 +15,11 @@
 
 #include <zephyr.h>
 
-#define BOARD_HAS_DCDC          DT_HAS_COMPAT_STATUS_OKAY(half_bridge)
-#define BOARD_HAS_PWM_PORT      DT_NODE_EXISTS(DT_CHILD(DT_PATH(outputs), pwm_switch))
-#define BOARD_HAS_LOAD_OUTPUT   DT_NODE_EXISTS(DT_CHILD(DT_PATH(outputs), load))
-#define BOARD_HAS_USB_OUTPUT    DT_NODE_EXISTS(DT_CHILD(DT_PATH(outputs), usb_pwr))
-#define BOARD_HAS_TEMP_FETS     DT_NODE_EXISTS(DT_CHILD(DT_PATH(adc_inputs), temp_fets))
-#define BOARD_HAS_TEMP_BAT      DT_NODE_EXISTS(DT_CHILD(DT_PATH(adc_inputs), temp_bat))
+#define BOARD_HAS_DCDC        DT_HAS_COMPAT_STATUS_OKAY(half_bridge)
+#define BOARD_HAS_PWM_PORT    DT_NODE_EXISTS(DT_CHILD(DT_PATH(outputs), pwm_switch))
+#define BOARD_HAS_LOAD_OUTPUT DT_NODE_EXISTS(DT_CHILD(DT_PATH(outputs), load))
+#define BOARD_HAS_USB_OUTPUT  DT_NODE_EXISTS(DT_CHILD(DT_PATH(outputs), usb_pwr))
+#define BOARD_HAS_TEMP_FETS   DT_NODE_EXISTS(DT_CHILD(DT_PATH(adc_inputs), temp_fets))
+#define BOARD_HAS_TEMP_BAT    DT_NODE_EXISTS(DT_CHILD(DT_PATH(adc_inputs), temp_bat))
 
 #endif /* BOARD_H_ */

--- a/app/src/daq.h
+++ b/app/src/daq.h
@@ -28,7 +28,7 @@ extern "C" {
 
 #include <stdint.h>
 
-#define ADC_SCALE_FLOAT 65536.0F    // 16-bit full scale
+#define ADC_SCALE_FLOAT 65536.0F // 16-bit full scale
 
 #ifdef CONFIG_SOC_SERIES_STM32G4X
 // Using internal reference buffer at VREF+ pin, set to 2048 mV
@@ -40,8 +40,9 @@ extern "C" {
 #define VREF (VREFINT_VALUE * VREFINT_CAL / (adc_raw_filtered(ADC_POS(vref_mcu)) >> 4))
 #endif
 
-#define ADC_GAIN(name) ((float)DT_PROP(DT_CHILD(DT_PATH(adc_inputs), name), multiplier) / \
-    DT_PROP(DT_CHILD(DT_PATH(adc_inputs), name), divider))
+#define ADC_GAIN(name) \
+    ((float)DT_PROP(DT_CHILD(DT_PATH(adc_inputs), name), multiplier) \
+     / DT_PROP(DT_CHILD(DT_PATH(adc_inputs), name), divider))
 
 #define ADC_OFFSET(name) (DT_PROP(DT_CHILD(DT_PATH(adc_inputs), name), offset))
 
@@ -61,18 +62,20 @@ extern "C" {
  * The channels must be specified in ascending order in the board.dts file.
  */
 // cppcheck-suppress syntaxError
-enum {
+enum
+{
     DT_FOREACH_CHILD(DT_PATH(adc_inputs), ADC_ENUM)
-    NUM_ADC_CH          // trick to get the number of elements
+    NUM_ADC_CH // trick to get the number of elements
 };
 
 /**
  * Struct to define upper and lower limit alerts for any ADC channel
  */
-typedef struct {
-    void (*callback)();         ///< Function to be called when limits are exceeded
-    uint16_t limit;             ///< ADC reading for lower limit
-    int16_t debounce_ms;        ///< Milliseconds delay for triggering alert
+typedef struct
+{
+    void (*callback)();  ///< Function to be called when limits are exceeded
+    uint16_t limit;      ///< ADC reading for lower limit
+    int16_t debounce_ms; ///< Milliseconds delay for triggering alert
 } AdcAlert;
 
 /**

--- a/app/src/daq_driver.c
+++ b/app/src/daq_driver.c
@@ -8,25 +8,25 @@
 
 #ifndef UNIT_TEST
 
-#include <stdint.h>
 #include <inttypes.h>
+#include <stdint.h>
 
-#include <zephyr.h>
 #include <drivers/gpio.h>
+#include <zephyr.h>
 
-#include <stm32_ll_system.h>
 #include <stm32_ll_adc.h>
+#include <stm32_ll_bus.h>
 #include <stm32_ll_dac.h>
 #include <stm32_ll_dma.h>
-#include <stm32_ll_bus.h>
+#include <stm32_ll_system.h>
 
-#include "dcdc.h"       // for low-level control function called by DMA
+#include "dcdc.h" // for low-level control function called by DMA
 
 #if defined(CONFIG_SOC_SERIES_STM32F0X) || defined(CONFIG_SOC_SERIES_STM32L0X)
 
 // automatic channel selection based on devicetree settings
 #define ADC_CHSEL_FN(node_id) (1UL << DT_PHA(node_id, io_channels, input)) |
-#define ADC_CHSEL (DT_FOREACH_CHILD(DT_PATH(adc_inputs), ADC_CHSEL_FN) 0)
+#define ADC_CHSEL             (DT_FOREACH_CHILD(DT_PATH(adc_inputs), ADC_CHSEL_FN) 0)
 
 int num_adc1_ch = NUM_ADC_CH;
 
@@ -34,15 +34,11 @@ int num_adc1_ch = NUM_ADC_CH;
 
 // create array with selected channel for each ADC input
 #define ADC_CH_NUM_(node_id) DT_PHA(node_id, io_channels, input),
-static const uint32_t adc_ch_numbers[] = {
-    DT_FOREACH_CHILD(DT_PATH(adc_inputs), ADC_CH_NUM_)
-};
+static const uint32_t adc_ch_numbers[] = { DT_FOREACH_CHILD(DT_PATH(adc_inputs), ADC_CH_NUM_) };
 
 // create array with ADC instance register address for each ADC input
-#define ADC_REG_(node_id) DT_REG_ADDR_BY_IDX(DT_PHANDLE(node_id, io_channels), 0),
-static const uint32_t adc_registers[] = {
-    DT_FOREACH_CHILD(DT_PATH(adc_inputs), ADC_REG_)
-};
+#define ADC_REG_(node_id)    DT_REG_ADDR_BY_IDX(DT_PHANDLE(node_id, io_channels), 0),
+static const uint32_t adc_registers[] = { DT_FOREACH_CHILD(DT_PATH(adc_inputs), ADC_REG_) };
 
 // number of channels per ADC peripheral will be calculated in adc_init function
 int num_adc1_ch = 0;
@@ -74,44 +70,30 @@ static const uint32_t table_channel[] = {
 
 // Rank and sequence definitions for STM32G4 from adc_stm32.c Zephyr driver
 
-#define RANK(n)		LL_ADC_REG_RANK_##n
+#define RANK(n) LL_ADC_REG_RANK_##n
 static const uint32_t table_rank[] = {
-	RANK(1),
-	RANK(2),
-	RANK(3),
-	RANK(4),
-	RANK(5),
-	RANK(6),
-	RANK(7),
-	RANK(8),
-	RANK(9),
-	RANK(10),
-	RANK(11),
-	RANK(12),
-	RANK(13),
-	RANK(14),
-	RANK(15),
-	RANK(16),
+    RANK(1), RANK(2),  RANK(3),  RANK(4),  RANK(5),  RANK(6),  RANK(7),  RANK(8),
+    RANK(9), RANK(10), RANK(11), RANK(12), RANK(13), RANK(14), RANK(15), RANK(16),
 };
 
-#define SEQ_LEN(n)	LL_ADC_REG_SEQ_SCAN_ENABLE_##n##RANKS
+#define SEQ_LEN(n) LL_ADC_REG_SEQ_SCAN_ENABLE_##n##RANKS
 static const uint32_t table_seq_len[] = {
-	LL_ADC_REG_SEQ_SCAN_DISABLE,
-	SEQ_LEN(2),
-	SEQ_LEN(3),
-	SEQ_LEN(4),
-	SEQ_LEN(5),
-	SEQ_LEN(6),
-	SEQ_LEN(7),
-	SEQ_LEN(8),
-	SEQ_LEN(9),
-	SEQ_LEN(10),
-	SEQ_LEN(11),
-	SEQ_LEN(12),
-	SEQ_LEN(13),
-	SEQ_LEN(14),
-	SEQ_LEN(15),
-	SEQ_LEN(16),
+    LL_ADC_REG_SEQ_SCAN_DISABLE,
+    SEQ_LEN(2),
+    SEQ_LEN(3),
+    SEQ_LEN(4),
+    SEQ_LEN(5),
+    SEQ_LEN(6),
+    SEQ_LEN(7),
+    SEQ_LEN(8),
+    SEQ_LEN(9),
+    SEQ_LEN(10),
+    SEQ_LEN(11),
+    SEQ_LEN(12),
+    SEQ_LEN(13),
+    SEQ_LEN(14),
+    SEQ_LEN(15),
+    SEQ_LEN(16),
 };
 
 #endif /* STM32G4X */
@@ -129,7 +111,8 @@ static void vref_setup()
     LL_VREFBUF_SetVoltageScaling(LL_VREFBUF_VOLTAGE_SCALE0);
     LL_VREFBUF_DisableHIZ();
     LL_VREFBUF_Enable();
-    while (LL_VREFBUF_IsVREFReady() == 0) {;}
+    while (LL_VREFBUF_IsVREFReady() == 0) {
+    }
 #endif
 }
 
@@ -138,18 +121,18 @@ static void dac_setup()
 #if defined(CONFIG_SOC_SERIES_STM32F0X) || defined(CONFIG_SOC_SERIES_STM32L0X)
     /* DAC1 at PA4 for load and DC/DC / PWM switch current measurement * VCC */
     LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_DAC1);
-	LL_DAC_SetOutputBuffer(DAC1, LL_DAC_CHANNEL_1, LL_DAC_OUTPUT_BUFFER_ENABLE);
-	LL_DAC_Enable(DAC1, LL_DAC_CHANNEL_1);
+    LL_DAC_SetOutputBuffer(DAC1, LL_DAC_CHANNEL_1, LL_DAC_OUTPUT_BUFFER_ENABLE);
+    LL_DAC_Enable(DAC1, LL_DAC_CHANNEL_1);
     LL_DAC_ConvertData12RightAligned(DAC1, LL_DAC_CHANNEL_1, 4096 / 10);
 #elif defined(CONFIG_SOC_SERIES_STM32G4X)
     LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_DAC1);
     /* DAC1 at PA4 for bi-directional DC/DC current measurement at 0.5 * VCC */
-	LL_DAC_SetOutputBuffer(DAC1, LL_DAC_CHANNEL_1, LL_DAC_OUTPUT_BUFFER_ENABLE);
-	LL_DAC_Enable(DAC1, LL_DAC_CHANNEL_1);
+    LL_DAC_SetOutputBuffer(DAC1, LL_DAC_CHANNEL_1, LL_DAC_OUTPUT_BUFFER_ENABLE);
+    LL_DAC_Enable(DAC1, LL_DAC_CHANNEL_1);
     LL_DAC_ConvertData12RightAligned(DAC1, LL_DAC_CHANNEL_1, 4096 / 2);
     /* DAC1 at PA5 for uni-directional PWM and load current measurement at 0.1 * VCC */
-	LL_DAC_SetOutputBuffer(DAC1, LL_DAC_CHANNEL_2, LL_DAC_OUTPUT_BUFFER_ENABLE);
-	LL_DAC_Enable(DAC1, LL_DAC_CHANNEL_2);
+    LL_DAC_SetOutputBuffer(DAC1, LL_DAC_CHANNEL_2, LL_DAC_OUTPUT_BUFFER_ENABLE);
+    LL_DAC_Enable(DAC1, LL_DAC_CHANNEL_2);
     LL_DAC_ConvertData12RightAligned(DAC1, LL_DAC_CHANNEL_2, 4096 / 10);
 #endif
 }
@@ -169,11 +152,11 @@ static void adc_init(ADC_TypeDef *adc)
     // ADC clock can be generated from SYSCLK or PLL (async mode) or derived from AHB clock
     // (sync mode). For synchronization with a timer, sync mode is preferred.
     LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_ADC12);
-    //LL_RCC_SetADCClockSource(LL_RCC_ADC12_CLKSOURCE_SYSCLK);
+    // LL_RCC_SetADCClockSource(LL_RCC_ADC12_CLKSOURCE_SYSCLK);
 
     // Use DIV1 only, as DIV2 and DIV4 lead to errors in ADC readings (not sure why...)
     LL_ADC_SetCommonClock(__LL_ADC_COMMON_INSTANCE(adc), LL_ADC_CLOCK_SYNC_PCLK_DIV1);
-    //LL_ADC_SetCommonClock(__LL_ADC_COMMON_INSTANCE(adc), LL_ADC_CLOCK_ASYNC_DIV1);
+    // LL_ADC_SetCommonClock(__LL_ADC_COMMON_INSTANCE(adc), LL_ADC_CLOCK_ASYNC_DIV1);
 
     // Prepare for ADC calibration
     LL_ADC_DisableDeepPowerDown(adc);
@@ -188,7 +171,8 @@ static void adc_init(ADC_TypeDef *adc)
 #elif defined(CONFIG_SOC_SERIES_STM32F0X) || defined(CONFIG_SOC_SERIES_STM32L0X)
     LL_ADC_StartCalibration(adc);
 #endif
-    while (LL_ADC_IsCalibrationOnGoing(adc)) {;}
+    while (LL_ADC_IsCalibrationOnGoing(adc)) {
+    }
 
     if (LL_ADC_IsActiveFlag_ADRDY(adc)) {
         LL_ADC_ClearFlag_ADRDY(adc);
@@ -196,13 +180,13 @@ static void adc_init(ADC_TypeDef *adc)
 
     // Enable internal reference voltage and temperature
     LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc),
-        LL_ADC_PATH_INTERNAL_VREFINT | LL_ADC_PATH_INTERNAL_TEMPSENSOR);
+                                   LL_ADC_PATH_INTERNAL_VREFINT | LL_ADC_PATH_INTERNAL_TEMPSENSOR);
 
 #if defined(CONFIG_SOC_SERIES_STM32F0X)
-	LL_ADC_REG_SetSequencerChannels(adc, ADC_CHSEL);
+    LL_ADC_REG_SetSequencerChannels(adc, ADC_CHSEL);
     LL_ADC_SetSamplingTimeCommonChannels(adc, LL_ADC_SAMPLINGTIME_239CYCLES_5);
 #elif defined(CONFIG_SOC_SERIES_STM32L0X)
-	LL_ADC_REG_SetSequencerChannels(adc, ADC_CHSEL);
+    LL_ADC_REG_SetSequencerChannels(adc, ADC_CHSEL);
     LL_ADC_SetSamplingTimeCommonChannels(adc, LL_ADC_SAMPLINGTIME_160CYCLES_5);
 #elif defined(CONFIG_SOC_SERIES_STM32G4X)
     // more complicated sequencer allows to define the sequence independent
@@ -212,10 +196,9 @@ static void adc_init(ADC_TypeDef *adc)
         if (adc_registers[i] == (uint32_t)adc) {
             uint32_t ch_number = adc_ch_numbers[i];
             if (ch_number < sizeof(table_channel)) {
-                LL_ADC_REG_SetSequencerRanks(adc,
-                    table_rank[*num_ch], table_channel[ch_number]);
-                LL_ADC_SetChannelSamplingTime(adc,
-                    table_channel[ch_number], LL_ADC_SAMPLINGTIME_247CYCLES_5);
+                LL_ADC_REG_SetSequencerRanks(adc, table_rank[*num_ch], table_channel[ch_number]);
+                LL_ADC_SetChannelSamplingTime(adc, table_channel[ch_number],
+                                              LL_ADC_SAMPLINGTIME_247CYCLES_5);
                 (*num_ch)++;
             }
         }
@@ -239,7 +222,7 @@ static void adc_setup()
 #if DT_NODE_EXISTS(DT_PROP(V_HIGH_ENABLE_GPIO, enable_gpios))
     const struct device *dev = device_get_binding(DT_GPIO_LABEL(V_HIGH_ENABLE_GPIO, enable_gpios));
     gpio_pin_configure(dev, DT_GPIO_PIN(V_HIGH_ENABLE_GPIO, enable_gpios),
-        DT_GPIO_FLAGS(V_HIGH_ENABLE_GPIO, enable_gpios) | GPIO_OUTPUT_ACTIVE);
+                       DT_GPIO_FLAGS(V_HIGH_ENABLE_GPIO, enable_gpios) | GPIO_OUTPUT_ACTIVE);
 #endif
 
     adc_init(ADC1);
@@ -268,7 +251,7 @@ static void DMA1_Channel1_IRQHandler(void *args)
             adc_update_value(i);
         }
     }
-    DMA1->IFCR |= 0x0FFFFFFF;       // clear all interrupt registers
+    DMA1->IFCR |= 0x0FFFFFFF; // clear all interrupt registers
 }
 
 #if defined(CONFIG_SOC_SERIES_STM32G4X)
@@ -279,7 +262,7 @@ static void DMA2_Channel1_IRQHandler(void *args)
             adc_update_value(i);
         }
     }
-    DMA2->IFCR |= 0x0FFFFFFF;       // clear all interrupt registers
+    DMA2->IFCR |= 0x0FFFFFFF; // clear all interrupt registers
 
 #ifdef CONFIG_CUSTOM_DCDC_CONTROLLER
     // Implement this function e.g. for cycle-by-cylce current limitation.
@@ -305,9 +288,10 @@ static void dma_init(DMA_TypeDef *dma)
     if (dma == DMA1) {
         LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_DMA1);
 
-        LL_DMA_ConfigAddresses(dma, LL_DMA_CHANNEL_1,
-            LL_ADC_DMA_GetRegAddr(ADC1, LL_ADC_DMA_REG_REGULAR_DATA),   // source address
-            (uint32_t)(&(adc_readings[0])),     // destination address
+        LL_DMA_ConfigAddresses(
+            dma, LL_DMA_CHANNEL_1,
+            LL_ADC_DMA_GetRegAddr(ADC1, LL_ADC_DMA_REG_REGULAR_DATA), // source address
+            (uint32_t)(&(adc_readings[0])),                           // destination address
             LL_DMA_DIRECTION_PERIPH_TO_MEMORY);
 
         // Configure the number of DMA transfers (data length in multiples of size per transfer)
@@ -318,11 +302,11 @@ static void dma_init(DMA_TypeDef *dma)
         LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_DMA2);
 
         // If DMA 2 is mapped to ADC 2
-        LL_DMA_ConfigAddresses(dma, LL_DMA_CHANNEL_1,
-            LL_ADC_DMA_GetRegAddr(ADC2, LL_ADC_DMA_REG_REGULAR_DATA),   // source address
+        LL_DMA_ConfigAddresses(
+            dma, LL_DMA_CHANNEL_1,
+            LL_ADC_DMA_GetRegAddr(ADC2, LL_ADC_DMA_REG_REGULAR_DATA), // source address
             // destination address = position behind ADC_1 values
-            (uint32_t)(&(adc_readings[num_adc1_ch])),
-            LL_DMA_DIRECTION_PERIPH_TO_MEMORY);
+            (uint32_t)(&(adc_readings[num_adc1_ch])), LL_DMA_DIRECTION_PERIPH_TO_MEMORY);
 
         // Configure the number of DMA transfers (data length in multiples of size per transfer)
         LL_DMA_SetDataLength(dma, LL_DMA_CHANNEL_1, num_adc2_ch);
@@ -332,8 +316,8 @@ static void dma_init(DMA_TypeDef *dma)
     LL_DMA_SetMemoryIncMode(dma, LL_DMA_CHANNEL_1, LL_DMA_MEMORY_INCREMENT);
     LL_DMA_SetMemorySize(dma, LL_DMA_CHANNEL_1, LL_DMA_MDATAALIGN_HALFWORD);
     LL_DMA_SetPeriphSize(dma, LL_DMA_CHANNEL_1, LL_DMA_PDATAALIGN_HALFWORD);
-    LL_DMA_EnableIT_TE(dma, LL_DMA_CHANNEL_1);     // transfer error interrupt
-    LL_DMA_EnableIT_TC(dma, LL_DMA_CHANNEL_1);     // transfer complete interrupt
+    LL_DMA_EnableIT_TE(dma, LL_DMA_CHANNEL_1); // transfer error interrupt
+    LL_DMA_EnableIT_TC(dma, LL_DMA_CHANNEL_1); // transfer complete interrupt
     LL_DMA_SetMode(dma, LL_DMA_CHANNEL_1, LL_DMA_MODE_CIRCULAR);
 
     LL_DMA_EnableChannel(dma, LL_DMA_CHANNEL_1);
@@ -372,9 +356,9 @@ void daq_setup()
     dma_setup();
 
     k_timer_init(&adc_trigger_timer, adc_trigger_conversion, NULL);
-    k_timer_start(&adc_trigger_timer, K_MSEC(1), K_MSEC(1));        // 1 kHz
+    k_timer_start(&adc_trigger_timer, K_MSEC(1), K_MSEC(1)); // 1 kHz
 
-    k_sleep(K_MSEC(500));      // wait for ADC to collect some measurement values
+    k_sleep(K_MSEC(500)); // wait for ADC to collect some measurement values
     daq_update();
     calibrate_current_sensors();
     daq_update();

--- a/app/src/data_objects.cpp
+++ b/app/src/data_objects.cpp
@@ -6,8 +6,8 @@
 
 #include "data_objects.h"
 
-#include <zephyr.h>
 #include <soc.h>
+#include <zephyr.h>
 
 #include <drivers/hwinfo.h>
 #include <sys/crc.h>
@@ -22,9 +22,9 @@
 #include "data_storage.h"
 #include "dcdc.h"
 #include "hardware.h"
+#include "helper.h"
 #include "setup.h"
 #include "thingset.h"
-#include "helper.h"
 
 LOG_MODULE_REGISTER(data_objects, CONFIG_DATA_OBJECTS_LOG_LEVEL);
 
@@ -72,6 +72,7 @@ uint16_t can_node_addr = CONFIG_THINGSET_CAN_DEFAULT_NODE_ID;
 /**
  * Thing Set Data Objects (see thingset.io for specification)
  */
+/* clang-format off */
 static ThingSetDataObject data_objects[] = {
 
     /*
@@ -1247,8 +1248,9 @@ static ThingSetDataObject data_objects[] = {
     TS_ITEM_FLOAT(0x7001, "CtrlTarget_A", &charger.target_current_control, 1,
         ID_CTRL, TS_ANY_RW, SUBSET_CTRL),
 };
+/* clang-format on */
 
-ThingSet ts(data_objects, sizeof(data_objects)/sizeof(ThingSetDataObject));
+ThingSet ts(data_objects, sizeof(data_objects) / sizeof(ThingSetDataObject));
 
 void data_objects_update_conf()
 {
@@ -1258,7 +1260,7 @@ void data_objects_update_conf()
         battery_conf_overwrite(&bat_conf_user, &bat_conf, &charger);
 #if BOARD_HAS_LOAD_OUTPUT
         load.set_voltage_limits(bat_conf.load_disconnect_voltage, bat_conf.load_reconnect_voltage,
-            bat_conf.absolute_max_voltage);
+                                bat_conf.absolute_max_voltage);
 #endif
         changed = true;
     }
@@ -1302,14 +1304,14 @@ void thingset_auth()
     static const char pass_exp[] = CONFIG_THINGSET_EXPERT_PASSWORD;
     static const char pass_mkr[] = CONFIG_THINGSET_MAKER_PASSWORD;
 
-    if (strlen(pass_exp) == strlen(auth_password) &&
-        strncmp(auth_password, pass_exp, strlen(pass_exp)) == 0)
+    if (strlen(pass_exp) == strlen(auth_password)
+        && strncmp(auth_password, pass_exp, strlen(pass_exp)) == 0)
     {
         LOG_INF("Authenticated as expert user.");
         ts.set_authentication(TS_EXP_MASK | TS_USR_MASK);
     }
-    else if (strlen(pass_mkr) == strlen(auth_password) &&
-        strncmp(auth_password, pass_mkr, strlen(pass_mkr)) == 0)
+    else if (strlen(pass_mkr) == strlen(auth_password)
+             && strncmp(auth_password, pass_mkr, strlen(pass_mkr)) == 0)
     {
         LOG_INF("Authenticated as maker.");
         ts.set_authentication(TS_MKR_MASK | TS_USR_MASK);
@@ -1334,7 +1336,7 @@ void uint64_to_base32(uint64_t in, char *out, size_t size, const char *alphabet)
     }
 
     for (int i = 0; i < len; i++) {
-        out[len-i-1] = alphabet[(in >> (i * 5)) % 32];
+        out[len - i - 1] = alphabet[(in >> (i * 5)) % 32];
     }
     out[len] = '\0';
 }

--- a/app/src/data_objects.h
+++ b/app/src/data_objects.h
@@ -18,27 +18,27 @@
 /*
  * Categories / first layer node IDs
  */
-#define ID_ROOT     0x00
-#define ID_INFO     0x01        // read-only device information (e.g. manufacturer, device ID)
-#define ID_MEAS     0x02        // output data (e.g. measurement values)
-#define ID_STATE    0x03        // recorded data (history-dependent)
-#define ID_REC      0x04        // recorded data (history-dependent)
-#define ID_INPUT    0x05        // input data (e.g. set-points)
-#define ID_CONF     0x06        // configurable settings
-#define ID_CAL      0x07        // calibration
-#define ID_REPORT   0x0A        // reports
-#define ID_RPC      0x0E        // remote procedure calls
-#define ID_DFU      0x0F        // device firmware upgrade
-#define ID_PUB      0x100       // publication setup
-#define ID_CTRL     0x8000      // control functions
+#define ID_ROOT   0x00
+#define ID_INFO   0x01   // read-only device information (e.g. manufacturer, device ID)
+#define ID_MEAS   0x02   // output data (e.g. measurement values)
+#define ID_STATE  0x03   // recorded data (history-dependent)
+#define ID_REC    0x04   // recorded data (history-dependent)
+#define ID_INPUT  0x05   // input data (e.g. set-points)
+#define ID_CONF   0x06   // configurable settings
+#define ID_CAL    0x07   // calibration
+#define ID_REPORT 0x0A   // reports
+#define ID_RPC    0x0E   // remote procedure calls
+#define ID_DFU    0x0F   // device firmware upgrade
+#define ID_PUB    0x100  // publication setup
+#define ID_CTRL   0x8000 // control functions
 
 /*
  * Subset definitions for statements and publish/subscribe
  */
-#define SUBSET_SER      (1U << 0)   // UART serial
-#define SUBSET_CAN      (1U << 1)   // CAN bus
-#define SUBSET_NVM      (1U << 2)   // data that should be stored in EEPROM
-#define SUBSET_CTRL     (1U << 3)   // control data sent and received via CAN
+#define SUBSET_SER  (1U << 0) // UART serial
+#define SUBSET_CAN  (1U << 1) // CAN bus
+#define SUBSET_NVM  (1U << 2) // data that should be stored in EEPROM
+#define SUBSET_CTRL (1U << 3) // control data sent and received via CAN
 
 /*
  * Data object versioning for EEPROM

--- a/app/src/data_storage.h
+++ b/app/src/data_storage.h
@@ -7,7 +7,7 @@
 #ifndef DATA_STORAGE_H_
 #define DATA_STORAGE_H_
 
-#define DATA_UPDATE_INTERVAL  (6*60*60)       // update every 6 hours
+#define DATA_UPDATE_INTERVAL (6 * 60 * 60) // update every 6 hours
 
 /**
  * @file

--- a/app/src/dcdc.cpp
+++ b/app/src/dcdc.cpp
@@ -11,14 +11,14 @@
 #include <device.h>
 #include <drivers/gpio.h>
 
-#include <math.h>       // for fabs function
-#include <stdlib.h>     // for min/max function
+#include <math.h> // for fabs function
 #include <stdio.h>
+#include <stdlib.h> // for min/max function
 
-#include "device_status.h"
-#include "helper.h"
-#include "half_bridge.h"
 #include "data_storage.h"
+#include "device_status.h"
+#include "half_bridge.h"
+#include "helper.h"
 #include "setup.h"
 
 LOG_MODULE_REGISTER(dcdc, CONFIG_DCDC_LOG_LEVEL);
@@ -35,26 +35,26 @@ Dcdc::Dcdc(DcBus *high, DcBus *low, DcdcOperationMode op_mode)
 {
     hvb = high;
     lvb = low;
-    mode           = op_mode;
-    enable         = true;
-    state          = DCDC_CONTROL_OFF;
+    mode = op_mode;
+    enable = true;
+    state = DCDC_CONTROL_OFF;
     inductor_current_max = DT_PROP(DT_PATH(pcb), dcdc_current_max);
     hs_voltage_max = DT_PROP(DT_PATH(pcb), hs_voltage_max);
     ls_voltage_max = DT_PROP(DT_PATH(pcb), ls_voltage_max);
     ls_voltage_min = 9.0;
-    output_power_min = 1;         // switch off if power < 1 W
+    output_power_min = 1; // switch off if power < 1 W
     restart_interval = 60;
-    off_timestamp = -10000;       // start immediately
-    pwm_delta = 1;                // start-condition of duty cycle pwr_inc_pwm_direction
+    off_timestamp = -10000; // start immediately
+    pwm_delta = 1;          // start-condition of duty cycle pwr_inc_pwm_direction
 
     // lower duty limit might have to be adjusted dynamically depending on LS voltage
     half_bridge_init(DT_PROP(DT_INST(0, half_bridge), frequency) / 1000,
-        DT_PROP(DT_INST(0, half_bridge), deadtime), 12 / hs_voltage_max, 0.97);
+                     DT_PROP(DT_INST(0, half_bridge), deadtime), 12 / hs_voltage_max, 0.97);
 }
 
 int Dcdc::perturb_observe_controller()
 {
-    int pwr_inc_pwm_direction;      // direction of PWM duty cycle change for increasing power
+    int pwr_inc_pwm_direction; // direction of PWM duty cycle change for increasing power
     DcBus *in;
     DcBus *out;
     float out_power;
@@ -75,10 +75,10 @@ int Dcdc::perturb_observe_controller()
     }
 
     if (out_power >= output_power_min) {
-        power_good_timestamp = uptime();     // reset the time
+        power_good_timestamp = uptime(); // reset the time
     }
 
-    int pwr_inc_goal = 0;     // stores if we want to increase (+1) or decrease (-1) power
+    int pwr_inc_goal = 0; // stores if we want to increase (+1) or decrease (-1) power
 
     if ((uptime() - power_good_timestamp > 10 || out_power < -10.0) && mode != DCDC_MODE_AUTO) {
         // switch off after 10s low power or negative power (if not in nanogrid mode)
@@ -87,22 +87,22 @@ int Dcdc::perturb_observe_controller()
     else if (out->voltage > out->sink_control_voltage()) {
         // output voltage target reached
         state = (out == lvb) ? DCDC_CONTROL_CV_LS : DCDC_CONTROL_CV_HS;
-        pwr_inc_goal = -1;  // decrease output power
+        pwr_inc_goal = -1; // decrease output power
     }
     else if (out->sink_current_margin < 0) {
         // output charge current limit reached
         state = (out == lvb) ? DCDC_CONTROL_CC_LS : DCDC_CONTROL_CC_HS;
-        pwr_inc_goal = -1;  // decrease output power
+        pwr_inc_goal = -1; // decrease output power
     }
     else if (in->src_current_margin > 0) {
         // input current (negative signs) limit exceeded
         state = (in == hvb) ? DCDC_CONTROL_CC_HS : DCDC_CONTROL_CC_LS;
-        pwr_inc_goal = -1;  // decrease output power
+        pwr_inc_goal = -1; // decrease output power
     }
     else if (fabs(inductor_current) > inductor_current_max) {
         // current above hardware maximum
         state = DCDC_CONTROL_CC_LS;
-        pwr_inc_goal = -1;  // decrease output power
+        pwr_inc_goal = -1; // decrease output power
     }
     else if (in->voltage < in->src_control_voltage() && out_power > output_power_min) {
         // input voltage below limit
@@ -116,7 +116,7 @@ int Dcdc::perturb_observe_controller()
     }
     else if (out_power < output_power_min && out->voltage < out->src_control_voltage()) {
         // no load condition (e.g. start-up of nanogrid) --> raise voltage
-        pwr_inc_goal = 1;   // increase output power
+        pwr_inc_goal = 1; // increase output power
     }
     else {
         // start MPPT
@@ -130,11 +130,11 @@ int Dcdc::perturb_observe_controller()
 #if CONFIG_DCDC_LOG_LEVEL == LOG_LEVEL_DBG
     // workaround as LOG_DBG does not support float printing
     printf("P: %.2fW (prev %.2fW), ind. current: %.2f, "
-        "in: %.2fV, %.2fA margin, out: %.2fV (target %.2fV), %.2fA margin, "
-        "PWM: %.1f, chg_state: %d, pwr_inc: %d, buck/boost: %d\n",
-        out_power, power_prev, inductor_current, in->voltage, in->src_current_margin,
-        out->voltage, out->sink_voltage_intercept, out->sink_current_margin,
-        half_bridge_get_duty_cycle() * 100.0, state, pwr_inc_goal, pwr_inc_pwm_direction);
+           "in: %.2fV, %.2fA margin, out: %.2fV (target %.2fV), %.2fA margin, "
+           "PWM: %.1f, chg_state: %d, pwr_inc: %d, buck/boost: %d\n",
+           out_power, power_prev, inductor_current, in->voltage, in->src_current_margin,
+           out->voltage, out->sink_voltage_intercept, out->sink_current_margin,
+           half_bridge_get_duty_cycle() * 100.0, state, pwr_inc_goal, pwr_inc_pwm_direction);
 #endif
 
     power_prev = out_power;
@@ -152,29 +152,24 @@ int Dcdc::perturb_observe_controller()
 
 __weak DcdcOperationMode Dcdc::check_start_conditions()
 {
-    if (enable == false ||
-        hvb->voltage > hs_voltage_max ||   // also critical for buck mode because of ringing
-        lvb->voltage > ls_voltage_max ||
-        lvb->voltage < ls_voltage_min ||
-        dev_stat.has_error(ERR_BAT_UNDERVOLTAGE | ERR_BAT_OVERVOLTAGE) ||
-        (int)uptime() < (off_timestamp + (int)restart_interval))
+    if (enable == false || hvb->voltage > hs_voltage_max
+        || // also critical for buck mode because of ringing
+        lvb->voltage > ls_voltage_max || lvb->voltage < ls_voltage_min
+        || dev_stat.has_error(ERR_BAT_UNDERVOLTAGE | ERR_BAT_OVERVOLTAGE)
+        || (int)uptime() < (off_timestamp + (int)restart_interval))
     {
         return DCDC_MODE_OFF;
     }
 
-    if (lvb->sink_current_margin > 0 &&
-        lvb->voltage < lvb->sink_control_voltage() &&
-        hvb->src_current_margin < 0 &&
-        hvb->voltage > hvb->src_control_voltage() &&
-        hvb->voltage * 0.85 > lvb->voltage)
+    if (lvb->sink_current_margin > 0 && lvb->voltage < lvb->sink_control_voltage()
+        && hvb->src_current_margin < 0 && hvb->voltage > hvb->src_control_voltage()
+        && hvb->voltage * 0.85 > lvb->voltage)
     {
         return DCDC_MODE_BUCK;
     }
 
-    if (hvb->sink_current_margin > 0 &&
-        hvb->voltage < hvb->sink_control_voltage() &&
-        lvb->src_current_margin < 0 &&
-        lvb->voltage > lvb->src_control_voltage())
+    if (hvb->sink_current_margin > 0 && hvb->voltage < hvb->sink_control_voltage()
+        && lvb->src_current_margin < 0 && lvb->voltage > lvb->src_control_voltage())
     {
         return DCDC_MODE_BOOST;
     }
@@ -250,11 +245,10 @@ __weak void Dcdc::control()
             half_bridge_start();
             power_good_timestamp = uptime();
             printf("DC/DC %s mode start (HV: %.2fV, LV: %.2fV, PWM: %.1f).\n", mode_name,
-                hvb->voltage, lvb->voltage, half_bridge_get_duty_cycle() * 100);
-
+                   hvb->voltage, lvb->voltage, half_bridge_get_duty_cycle() * 100);
         }
         else {
-            startup_inhibit(true);      // reset inhibit counter
+            startup_inhibit(true); // reset inhibit counter
         }
     }
     else { // half bridge is on
@@ -269,7 +263,7 @@ __weak void Dcdc::control()
         else {
             int err = perturb_observe_controller();
             if (err != 0) {
-                stop_reason =  "low power";
+                stop_reason = "low power";
             }
         }
 
@@ -312,11 +306,11 @@ void Dcdc::test()
 
             half_bridge_set_duty_cycle(lvb->voltage / hvb->voltage);
             half_bridge_start();
-            printf("DC/DC test mode start (HV: %.2fV, LV: %.2fV, PWM: %.1f).\n",
-                hvb->voltage, lvb->voltage, half_bridge_get_duty_cycle() * 100);
+            printf("DC/DC test mode start (HV: %.2fV, LV: %.2fV, PWM: %.1f).\n", hvb->voltage,
+                   lvb->voltage, half_bridge_get_duty_cycle() * 100);
         }
         else {
-            startup_inhibit(true);      // reset inhibit counter
+            startup_inhibit(true); // reset inhibit counter
         }
     }
 }
@@ -332,11 +326,11 @@ void Dcdc::fuse_destruction()
 {
     static int counter = 0;
 
-    if (counter > 20) {     // wait 20s to be able to send out data
+    if (counter > 20) { // wait 20s to be able to send out data
         LOG_ERR("Charge controller fuse destruction called!\n");
         data_storage_write();
         half_bridge_stop();
-        half_bridge_init(50, 0, 0, 0.98);   // reset safety limits to allow 0% duty cycle
+        half_bridge_init(50, 0, 0, 0.98); // reset safety limits to allow 0% duty cycle
         half_bridge_set_duty_cycle(0);
         half_bridge_start();
         // now the fuse should be triggered and we disappear
@@ -350,7 +344,7 @@ void Dcdc::output_hvs_enable()
     const struct device *hv_out = DEVICE_DT_GET(DT_GPIO_CTLR(HV_OUT_NODE, gpios));
     if (device_is_ready(hv_out)) {
         gpio_pin_configure(hv_out, DT_GPIO_PIN(HV_OUT_NODE, gpios),
-            DT_GPIO_FLAGS(HV_OUT_NODE, gpios) | GPIO_OUTPUT_ACTIVE);
+                           DT_GPIO_FLAGS(HV_OUT_NODE, gpios) | GPIO_OUTPUT_ACTIVE);
     }
 #endif
 }
@@ -361,7 +355,7 @@ void Dcdc::output_hvs_disable()
     const struct device *hv_out = DEVICE_DT_GET(DT_GPIO_CTLR(HV_OUT_NODE, gpios));
     if (device_is_ready(hv_out)) {
         gpio_pin_configure(hv_out, DT_GPIO_PIN(HV_OUT_NODE, gpios),
-            DT_GPIO_FLAGS(HV_OUT_NODE, gpios) | GPIO_OUTPUT_INACTIVE);
+                           DT_GPIO_FLAGS(HV_OUT_NODE, gpios) | GPIO_OUTPUT_INACTIVE);
     }
 #endif
 }

--- a/app/src/dcdc.h
+++ b/app/src/dcdc.h
@@ -16,14 +16,14 @@
  * hardware. The PWM signal for the half bridge is generated in a separate module.
  */
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef __cplusplus
 
 #include "power_port.h"
 
-#define DCDC_STARTUP_INHIBIT_TIME 3     // seconds
+#define DCDC_STARTUP_INHIBIT_TIME 3 // seconds
 
 /**
  * DC/DC operation mode
@@ -69,13 +69,13 @@ enum DcdcOperationMode
  */
 enum DcdcControlState
 {
-    DCDC_CONTROL_OFF,           ///< DC/DC switched off (low input power or actively disabled)
-    DCDC_CONTROL_MPPT,          ///< Maximum Power Point Tracking
-    DCDC_CONTROL_CC_LS,         ///< Constant-Current control at low-side
-    DCDC_CONTROL_CV_LS,         ///< Constant-Voltage control at low-side
-    DCDC_CONTROL_CC_HS,         ///< Constant-Current control at high-side
-    DCDC_CONTROL_CV_HS,         ///< Constant-Voltage control at high-side
-    DCDC_CONTROL_DERATING       ///< Hardware-limits (current or temperature) reached
+    DCDC_CONTROL_OFF,     ///< DC/DC switched off (low input power or actively disabled)
+    DCDC_CONTROL_MPPT,    ///< Maximum Power Point Tracking
+    DCDC_CONTROL_CC_LS,   ///< Constant-Current control at low-side
+    DCDC_CONTROL_CV_LS,   ///< Constant-Voltage control at low-side
+    DCDC_CONTROL_CC_HS,   ///< Constant-Current control at high-side
+    DCDC_CONTROL_CV_HS,   ///< Constant-Voltage control at high-side
+    DCDC_CONTROL_DERATING ///< Hardware-limits (current or temperature) reached
 };
 
 /**
@@ -96,7 +96,7 @@ public:
      * @param low Low voltage bus (e.g. battery output for MPPT buck)
      * @param mode Operation mode (buck, boost or nanogrid)
      */
-    Dcdc(DcBus *high, DcBus* low, DcdcOperationMode mode);
+    Dcdc(DcBus *high, DcBus *low, DcdcOperationMode mode);
 
     /**
      * Check for valid start conditions of the DC/DC converter
@@ -135,33 +135,33 @@ public:
      */
     void fuse_destruction();
 
-    DcdcOperationMode mode;     ///< DC/DC mode (buck, boost or nanogrid)
-    bool enable;                ///< Can be used to disable the DC/DC power stage
-    uint16_t state;             ///< Control state (off / MPPT / CC / CV)
+    DcdcOperationMode mode; ///< DC/DC mode (buck, boost or nanogrid)
+    bool enable;            ///< Can be used to disable the DC/DC power stage
+    uint16_t state;         ///< Control state (off / MPPT / CC / CV)
 
     // actual measurements
-    DcBus *hvb;                 ///< Pointer to DC bus at high voltage side
-    DcBus *lvb;                 ///< Pointer to DC bus at low voltage (inductor) side
-    float inductor_current;     ///< Inductor current
-    float power;                ///< Low-side power
-    float temp_mosfets;         ///< MOSFET temperature measurement (if existing)
+    DcBus *hvb;             ///< Pointer to DC bus at high voltage side
+    DcBus *lvb;             ///< Pointer to DC bus at low voltage (inductor) side
+    float inductor_current; ///< Inductor current
+    float power;            ///< Low-side power
+    float temp_mosfets;     ///< MOSFET temperature measurement (if existing)
 
     // current state
-    float power_prev;           ///< Stores previous conversion power (set via dcdc_control)
-    int32_t pwm_delta;          ///< Direction of PWM change for MPPT
-    int32_t off_timestamp;      ///< Last time the DC/DC was switched off
-    int32_t power_good_timestamp;   ///< Last time the DC/DC reached above minimum output power
+    float power_prev;             ///< Stores previous conversion power (set via dcdc_control)
+    int32_t pwm_delta;            ///< Direction of PWM change for MPPT
+    int32_t off_timestamp;        ///< Last time the DC/DC was switched off
+    int32_t power_good_timestamp; ///< Last time the DC/DC reached above minimum output power
 
     // maximum allowed values
-    float inductor_current_max = 0;   ///< Maximum low-side (inductor) current
-    float hs_voltage_max = 0;   ///< Maximum high-side voltage
-    float ls_voltage_max;       ///< Maximum low-side voltage
-    float ls_voltage_min;       ///< Minimum low-side voltage, e.g. for driver supply
-    float output_power_min;     ///< Minimum output power (if lower, DC/DC is switched off)
+    float inductor_current_max = 0; ///< Maximum low-side (inductor) current
+    float hs_voltage_max = 0;       ///< Maximum high-side voltage
+    float ls_voltage_max;           ///< Maximum low-side voltage
+    float ls_voltage_min;           ///< Minimum low-side voltage, e.g. for driver supply
+    float output_power_min;         ///< Minimum output power (if lower, DC/DC is switched off)
 
     // calibration parameters
-    uint32_t restart_interval;  ///< Restart interval (s): When should we retry to start
-                                ///< charging after low output power cut-off?
+    uint32_t restart_interval; ///< Restart interval (s): When should we retry to start
+                               ///< charging after low output power cut-off?
 
 private:
     /**
@@ -201,7 +201,6 @@ private:
 };
 
 #endif // __cplusplus
-
 
 #ifdef __cplusplus
 extern "C" {

--- a/app/src/device_status.cpp
+++ b/app/src/device_status.cpp
@@ -8,11 +8,11 @@
 
 #include <zephyr.h>
 
-#include <math.h>       // for fabs function
+#include <math.h> // for fabs function
 #include <stdio.h>
 
-#include "setup.h"
 #include "helper.h"
+#include "setup.h"
 
 //----------------------------------------------------------------------------
 // must be called exactly once per second, otherwise energy calculation gets wrong
@@ -27,10 +27,10 @@ void DeviceStatus::update_energy()
     static uint32_t load_out_total_Wh_prev;
     static uint32_t bat_chg_total_Wh_prev;
     static uint32_t bat_dis_total_Wh_prev;
-    #if CONFIG_HV_TERMINAL_NANOGRID
+#if CONFIG_HV_TERMINAL_NANOGRID
     static uint32_t grid_import_total_Wh_prev;
     static uint32_t grid_export_total_Wh_prev;
-    #endif
+#endif
 
     static bool first_call = true;
     if (first_call) {
@@ -39,10 +39,10 @@ void DeviceStatus::update_energy()
         load_out_total_Wh_prev = load_out_total_Wh;
         bat_chg_total_Wh_prev = bat_chg_total_Wh;
         bat_dis_total_Wh_prev = bat_dis_total_Wh;
-        #if CONFIG_HV_TERMINAL_NANOGRID
+#if CONFIG_HV_TERMINAL_NANOGRID
         grid_import_total_Wh_prev = grid_import_total_Wh;
         grid_export_total_Wh_prev = grid_export_total_Wh;
-        #endif
+#endif
         first_call = false;
     }
 
@@ -57,51 +57,50 @@ void DeviceStatus::update_energy()
     else {
         // solar voltage > battery voltage after 5 hours of night time means sunrise in the morning
         // --> reset daily energy counters
-        if (seconds_zero_solar > 60*60*5) {
+        if (seconds_zero_solar > 60 * 60 * 5) {
             day_counter++;
             solar_in_total_Wh_prev = solar_in_total_Wh;
             load_out_total_Wh_prev = load_out_total_Wh;
             bat_chg_total_Wh_prev = bat_chg_total_Wh;
             bat_dis_total_Wh_prev = bat_dis_total_Wh;
-            #if CONFIG_HV_TERMINAL_NANOGRID
+#if CONFIG_HV_TERMINAL_NANOGRID
             grid_import_total_Wh_prev = grid_import_total_Wh;
             grid_export_total_Wh_prev = grid_export_total_Wh;
-            #endif
+#endif
             solar_terminal.neg_energy_Wh = 0.0;
-            #if BOARD_HAS_LOAD_OUTPUT
+#if BOARD_HAS_LOAD_OUTPUT
             load.pos_energy_Wh = 0.0;
-            #endif
+#endif
             bat_terminal.pos_energy_Wh = 0.0;
             bat_terminal.neg_energy_Wh = 0.0;
-            #if CONFIG_HV_TERMINAL_NANOGRID
+#if CONFIG_HV_TERMINAL_NANOGRID
             grid_terminal.pos_energy_Wh = 0.0;
             grid_terminal.neg_energy_Wh = 0.0;
-            #endif
+#endif
         }
         seconds_zero_solar = 0;
     }
 #endif
 
-    bat_chg_total_Wh = bat_chg_total_Wh_prev +
-        (bat_terminal.pos_energy_Wh > 0 ? bat_terminal.pos_energy_Wh : 0);
-    bat_dis_total_Wh = bat_dis_total_Wh_prev +
-        (bat_terminal.neg_energy_Wh > 0 ? bat_terminal.neg_energy_Wh : 0);
+    bat_chg_total_Wh =
+        bat_chg_total_Wh_prev + (bat_terminal.pos_energy_Wh > 0 ? bat_terminal.pos_energy_Wh : 0);
+    bat_dis_total_Wh =
+        bat_dis_total_Wh_prev + (bat_terminal.neg_energy_Wh > 0 ? bat_terminal.neg_energy_Wh : 0);
 
 #if CONFIG_HV_TERMINAL_SOLAR || CONFIG_LV_TERMINAL_SOLAR || CONFIG_PWM_TERMINAL_SOLAR
-    solar_in_total_Wh = solar_in_total_Wh_prev +
-        (solar_terminal.neg_energy_Wh > 0 ? solar_terminal.neg_energy_Wh : 0);
+    solar_in_total_Wh = solar_in_total_Wh_prev
+                        + (solar_terminal.neg_energy_Wh > 0 ? solar_terminal.neg_energy_Wh : 0);
 #endif
 
 #if BOARD_HAS_LOAD_OUTPUT
-    load_out_total_Wh = load_out_total_Wh_prev +
-        (load.pos_energy_Wh > 0 ? load.pos_energy_Wh : 0);
+    load_out_total_Wh = load_out_total_Wh_prev + (load.pos_energy_Wh > 0 ? load.pos_energy_Wh : 0);
 #endif
 
 #if CONFIG_HV_TERMINAL_NANOGRID
-    grid_import_total_Wh = grid_import_total_Wh_prev +
-        (grid_terminal.neg_energy_Wh > 0 ? grid_terminal.neg_energy_Wh : 0);
-    grid_export_total_Wh = grid_export_total_Wh_prev +
-        (grid_terminal.pos_energy_Wh > 0 ? grid_terminal.pos_energy_Wh : 0);
+    grid_import_total_Wh = grid_import_total_Wh_prev
+                           + (grid_terminal.neg_energy_Wh > 0 ? grid_terminal.neg_energy_Wh : 0);
+    grid_export_total_Wh = grid_export_total_Wh_prev
+                           + (grid_terminal.pos_energy_Wh > 0 ? grid_terminal.pos_energy_Wh : 0);
 #endif
 }
 

--- a/app/src/device_status.h
+++ b/app/src/device_status.h
@@ -14,9 +14,9 @@
  */
 
 #include "bat_charger.h"
-#include "power_port.h"
-#include "load.h"
 #include "dcdc.h"
+#include "load.h"
+#include "power_port.h"
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -25,8 +25,8 @@
  * When adding new flags, please make sure to use only up to 32 errors
  * Each enum must represent a unique power of 2 number
  */
-enum ErrorFlag {
-
+enum ErrorFlag
+{
     /** Battery voltage too low
      *
      * Set and cleared in Charger::discharge_control() if the battery voltage dropped to lower than
@@ -113,7 +113,6 @@ enum ErrorFlag {
 class DeviceStatus
 {
 public:
-
     /** Updates the total energy counters for solar, battery and load bus
      */
     void update_energy();
@@ -127,10 +126,10 @@ public:
     uint32_t bat_dis_total_Wh;
     uint32_t solar_in_total_Wh;
     uint32_t load_out_total_Wh;
-    #if CONFIG_HV_TERMINAL_NANOGRID
+#if CONFIG_HV_TERMINAL_NANOGRID
     uint32_t grid_import_total_Wh;
     uint32_t grid_export_total_Wh;
-    #endif
+#endif
 
     // maximum/minimum values
     uint16_t solar_power_max_day;
@@ -141,34 +140,43 @@ public:
     float solar_voltage_max;
     float dcdc_current_max;
     float load_current_max;
-    int16_t bat_temp_max;         // °C
-    int16_t int_temp_max;         // °C
+    int16_t bat_temp_max; // °C
+    int16_t int_temp_max; // °C
     int16_t mosfet_temp_max;
 
     uint32_t day_counter;
 
     // instantaneous device-level data
-    uint32_t error_flags;       ///< Currently detected errors
-    float internal_temp;        ///< Internal temperature (measured in MCU)
+    uint32_t error_flags; ///< Currently detected errors
+    float internal_temp;  ///< Internal temperature (measured in MCU)
 
     /**
      * @brief sets one or more error flags in device state
      * @param e a single ErrorFlag or "bitwise ORed" ERR_XXX | ERR_YYY
      */
-    void set_error(uint32_t e) { error_flags |= e; }
+    inline void set_error(uint32_t e)
+    {
+        error_flags |= e;
+    }
 
     /**
      * @brief clears one or more error flags in device state
      * @param e a single ErrorFlag or "bitwise ORed" ERR_XXX | ERR_YYY
      */
-    void clear_error(uint32_t e) { error_flags &= ~e; }
+    void clear_error(uint32_t e)
+    {
+        error_flags &= ~e;
+    }
 
     /**
      * @brief queries one or more error flags in device state
      * @param e a single ErrorFlag or "bitwise ORed" ERR_XXX | ERR_YYY
      * @return true if any of the error flags given in e are set in device state
      */
-    bool has_error(uint32_t e) { return (error_flags & e) != 0; }
+    bool has_error(uint32_t e)
+    {
+        return (error_flags & e) != 0;
+    }
 };
 
 #endif /* DEVICE_STATUS_H */

--- a/app/src/ext/oled.cpp
+++ b/app/src/ext/oled.cpp
@@ -9,36 +9,34 @@
 #include <math.h>
 #include <stdio.h>
 
-#include <zephyr.h>
 #include <device.h>
 #include <drivers/gpio.h>
+#include <zephyr.h>
 
 #include "oled_ssd1306.h"
 
-#include "setup.h"
 #include "half_bridge.h"
+#include "setup.h"
 
 #if DT_NODE_EXISTS(DT_CHILD(DT_PATH(outputs), uext_en))
 #define UEXT_EN_GPIO DT_CHILD(DT_PATH(outputs), uext_en)
 #endif
 
-const unsigned char bmp_load [] = {
+const unsigned char bmp_load[] = {
     0x20, 0x22, 0x04, 0x70, 0x88, 0x8B, 0x88, 0x70, 0x04, 0x22, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00,
-    0x00, 0x01, 0x00, 0x00, 0x07, 0x04, 0x07, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    0x00, 0x01, 0x00, 0x00, 0x07, 0x04, 0x07, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
-const unsigned char bmp_arrow_right [] = {
-    0x41, 0x63, 0x36, 0x1C
-};
+const unsigned char bmp_arrow_right[] = { 0x41, 0x63, 0x36, 0x1C };
 
-const unsigned char bmp_pv_panel [] = {
+const unsigned char bmp_pv_panel[] = {
     0x60, 0x98, 0x86, 0xC9, 0x31, 0x19, 0x96, 0x62, 0x32, 0x2C, 0xC4, 0x64, 0x98, 0x08, 0xC8, 0x30,
-    0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x02, 0x02, 0x03, 0x04, 0x04, 0x04, 0x03, 0x00, 0x00
+    0x00, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x02, 0x02, 0x03, 0x04, 0x04, 0x04, 0x03, 0x00, 0x00,
 };
 
-const unsigned char bmp_disconnected [] = {
+const unsigned char bmp_disconnected[] = {
     0x08, 0x08, 0x08, 0x08, 0x00, 0x41, 0x63, 0x36, 0x1C, 0x1C, 0x36, 0x63, 0x41, 0x00, 0x08, 0x08,
-    0x08, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+    0x08, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
 OledSSD1306 oled(DT_LABEL(DT_ALIAS(i2c_uext)));
@@ -73,23 +71,23 @@ void oled_update()
         oled.drawBitmap(81, 3, bmp_disconnected, 17, 7, 1);
     }
 
-    oled.drawRect(52, 2, 18, 9, 1);     // battery shape
-    oled.drawRect(69, 3, 3, 7, 1);      // battery terminal
+    oled.drawRect(52, 2, 18, 9, 1); // battery shape
+    oled.drawRect(69, 3, 3, 7, 1);  // battery terminal
 
     if (charger.soc >= 20) {
-        oled.drawRect(54, 4, 2, 5, 1);      // bar 1
+        oled.drawRect(54, 4, 2, 5, 1); // bar 1
     }
     if (charger.soc >= 40) {
-        oled.drawRect(57, 4, 2, 5, 1);      // bar 2
+        oled.drawRect(57, 4, 2, 5, 1); // bar 2
     }
     if (charger.soc >= 60) {
-        oled.drawRect(60, 4, 2, 5, 1);      // bar 3
+        oled.drawRect(60, 4, 2, 5, 1); // bar 3
     }
     if (charger.soc >= 80) {
-        oled.drawRect(63, 4, 2, 5, 1);      // bar 4
+        oled.drawRect(63, 4, 2, 5, 1); // bar 4
     }
     if (charger.soc >= 95) {
-        oled.drawRect(66, 4, 2, 5, 1);      // bar 5
+        oled.drawRect(66, 4, 2, 5, 1); // bar 5
     }
 
     // solar panel data
@@ -100,7 +98,8 @@ void oled_update()
 #endif
         oled.setTextCursor(0, 18);
         len = snprintf(buf, sizeof(buf), "%4.0fW",
-            (abs(in_terminal.power) < 1) ? 0 : -in_terminal.power);  // remove negative zeros
+                       (abs(in_terminal.power) < 1) ? 0
+                                                    : -in_terminal.power); // remove negative zeros
         oled.writeString(buf, len);
     }
     else {
@@ -119,8 +118,9 @@ void oled_update()
 
     // battery data
     oled.setTextCursor(42, 18);
-    len = snprintf(buf, sizeof(buf), "%5.1fW",
-        (abs(bat_terminal.power) < 0.1) ? 0 : bat_terminal.power);    // remove negative zeros
+    len =
+        snprintf(buf, sizeof(buf), "%5.1fW",
+                 (abs(bat_terminal.power) < 0.1) ? 0 : bat_terminal.power); // remove negative zeros
     oled.writeString(buf, len);
     oled.setTextCursor(42, 26);
     len = snprintf(buf, sizeof(buf), "%5.1fV", bat_terminal.bus->voltage);
@@ -129,19 +129,18 @@ void oled_update()
     // load data
     oled.setTextCursor(90, 18);
     len = snprintf(buf, sizeof(buf), "%5.1fW",
-        (abs(load.power) < 0.1) ? 0 : load.power);    // remove negative zeros
+                   (abs(load.power) < 0.1) ? 0 : load.power); // remove negative zeros
     oled.writeString(buf, len);
     oled.setTextCursor(90, 26);
-    len = snprintf(buf, sizeof(buf), "%5.1fA\n",
-        (abs(load.current) < 0.1) ? 0 : load.current);
+    len = snprintf(buf, sizeof(buf), "%5.1fA\n", (abs(load.current) < 0.1) ? 0 : load.current);
     oled.writeString(buf, len);
 
     oled.setTextCursor(0, 36);
-    len = snprintf(buf, sizeof(buf), "Day +%5.0fWh -%5.0fWh",
-        in_terminal.neg_energy_Wh, fabs(load.pos_energy_Wh));
+    len = snprintf(buf, sizeof(buf), "Day +%5.0fWh -%5.0fWh", in_terminal.neg_energy_Wh,
+                   fabs(load.pos_energy_Wh));
     oled.writeString(buf, len);
-    len = snprintf(buf, sizeof(buf), "Tot +%4.1fkWh -%4.1fkWh",
-        dev_stat.solar_in_total_Wh / 1000.0, fabs(dev_stat.load_out_total_Wh) / 1000.0);
+    len = snprintf(buf, sizeof(buf), "Tot +%4.1fkWh -%4.1fkWh", dev_stat.solar_in_total_Wh / 1000.0,
+                   fabs(dev_stat.load_out_total_Wh) / 1000.0);
     oled.writeString(buf, len);
 
     oled.setTextCursor(0, 56);
@@ -154,12 +153,12 @@ void oled_update()
     float duty_cycle = half_bridge_get_duty_cycle();
 #endif
 
-    float temp = charger.ext_temp_sensor ? charger.bat_temperature:dev_stat.internal_temp;
+    float temp = charger.ext_temp_sensor ? charger.bat_temperature : dev_stat.internal_temp;
     char tC = charger.ext_temp_sensor ? 'T' : 't';
 
     if (pwm_enabled == true) {
-        len = snprintf(buf, sizeof(buf), "%c %.0fC PWM %.0f%% SOC %d%%",
-            tC, temp, duty_cycle * 100.0, charger.soc);
+        len = snprintf(buf, sizeof(buf), "%c %.0fC PWM %.0f%% SOC %d%%", tC, temp,
+                       duty_cycle * 100.0, charger.soc);
         oled.writeString(buf, len);
     }
     else {
@@ -175,7 +174,7 @@ void oled_thread()
 #if DT_NODE_EXISTS(DT_CHILD(DT_PATH(outputs), uext_en))
     const struct device *dev_uext_en = device_get_binding(DT_GPIO_LABEL(UEXT_EN_GPIO, gpios));
     gpio_pin_configure(dev_uext_en, DT_GPIO_PIN(UEXT_EN_GPIO, gpios),
-        DT_GPIO_FLAGS(UEXT_EN_GPIO, gpios) | GPIO_OUTPUT_ACTIVE);
+                       DT_GPIO_FLAGS(UEXT_EN_GPIO, gpios) | GPIO_OUTPUT_ACTIVE);
 #endif
 
     oled.init(CONFIG_UEXT_OLED_BRIGHTNESS);

--- a/app/src/ext/serial.cpp
+++ b/app/src/ext/serial.cpp
@@ -6,17 +6,17 @@
 
 #if CONFIG_THINGSET_SERIAL
 
-#include <string.h>
 #include <stdio.h>
+#include <string.h>
 
-#include <zephyr.h>
-#include <sys/printk.h>
 #include <drivers/uart.h>
+#include <sys/printk.h>
 #include <task_wdt/task_wdt.h>
+#include <zephyr.h>
 
-#include "thingset.h"
-#include "hardware.h"
 #include "data_objects.h"
+#include "hardware.h"
+#include "thingset.h"
 
 #if CONFIG_UEXT_SERIAL_THINGSET
 #define UART_DEVICE_NODE DT_ALIAS(uart_uext)
@@ -34,8 +34,8 @@ static char rx_buf[CONFIG_THINGSET_SERIAL_RX_BUF_SIZE];
 
 static volatile size_t rx_buf_pos = 0;
 
-static struct k_sem command_flag;       // used as an event to signal a received command
-static struct k_sem rx_buf_mutex;       // binary semaphore used as mutex in ISR context
+static struct k_sem command_flag; // used as an event to signal a received command
+static struct k_sem rx_buf_mutex; // binary semaphore used as mutex in ISR context
 
 extern ThingSet ts;
 
@@ -59,8 +59,7 @@ void serial_process_command()
     if (rx_buf_pos > 1) {
         printf("Received Request (%d bytes): %s\n", strlen(rx_buf), rx_buf);
 
-        int len = ts.process((uint8_t *)rx_buf, strlen(rx_buf),
-            (uint8_t *)tx_buf, sizeof(tx_buf));
+        int len = ts.process((uint8_t *)rx_buf, strlen(rx_buf), (uint8_t *)tx_buf, sizeof(tx_buf));
 
         for (int i = 0; i < len; i++) {
             uart_poll_out(uart_dev, tx_buf[i]);
@@ -76,7 +75,7 @@ void serial_process_command()
 /*
  * Read characters from stream until line end \n is detected, afterwards signal available command.
  */
-void serial_cb(const struct device *dev, void* user_data)
+void serial_cb(const struct device *dev, void *user_data)
 {
     uint8_t c;
 
@@ -92,8 +91,8 @@ void serial_cb(const struct device *dev, void* user_data)
         // we accept this at any time, even if the buffer is 'full', since
         // there is always one last character left for the \0
         if (c == '\n') {
-            if (rx_buf_pos > 0 && rx_buf[rx_buf_pos-1] == '\r') {
-                rx_buf[rx_buf_pos-1] = '\0';
+            if (rx_buf_pos > 0 && rx_buf[rx_buf_pos - 1] == '\r') {
+                rx_buf[rx_buf_pos - 1] = '\0';
             }
             else {
                 rx_buf[rx_buf_pos] = '\0';

--- a/app/src/half_bridge.cpp
+++ b/app/src/half_bridge.cpp
@@ -14,8 +14,8 @@
 #include "setup.h"
 
 #ifdef CONFIG_SOC_FAMILY_STM32
-#include <soc.h>
 #include <pinmux/pinmux_stm32.h>
+#include <soc.h>
 #include <stm32_ll_bus.h>
 #endif
 
@@ -26,7 +26,7 @@
 // Get address of used timer from board dts
 #define TIMER_ADDR DT_REG_ADDR(DT_PARENT(DT_DRV_INST(0)))
 
-static uint16_t tim_ccr_min;        // capture/compare register min/max
+static uint16_t tim_ccr_min; // capture/compare register min/max
 static uint16_t tim_ccr_max;
 static uint16_t tim_dt_clocks = 0;
 
@@ -81,7 +81,7 @@ static void tim_init_registers(int freq_kHz)
     // Auto Reload Register
     // center-aligned mode counts up and down in each period, so we need half the clocks as
     // resolution for the given frequency.
-    TIM3->ARR = SystemCoreClock / (freq_kHz * 1000) / 2;;
+    TIM3->ARR = SystemCoreClock / (freq_kHz * 1000) / 2;
 }
 
 void half_bridge_start()
@@ -115,8 +115,8 @@ void half_bridge_set_ccr(uint16_t ccr)
 {
     uint16_t ccr_clamped = clamp_ccr(ccr);
 
-    TIM3->CCR3 = ccr_clamped;                   // high-side
-    TIM3->CCR4 = ccr_clamped + tim_dt_clocks;   // low-side
+    TIM3->CCR3 = ccr_clamped;                 // high-side
+    TIM3->CCR4 = ccr_clamped + tim_dt_clocks; // low-side
 }
 
 bool half_bridge_enabled()
@@ -162,7 +162,7 @@ static void tim_init_registers(int freq_kHz)
     TIM1->CCMR3 |= TIM_CCMR3_OC6M_2 | TIM_CCMR3_OC6M_1 | TIM_CCMR3_OC6PE;
     TIM1->CCER |= TIM_CCER_CC6E;
     // Trigger ADC via TIM1_TRGO2 on OC6ref falling edge signal event
-    TIM1->CR2 |= TIM_CR2_MMS2_3 | TIM_CR2_MMS2_2 |  TIM_CR2_MMS2_0;
+    TIM1->CR2 |= TIM_CR2_MMS2_3 | TIM_CR2_MMS2_2 | TIM_CR2_MMS2_0;
 #endif
 
     // Force update generation (UG = 1)
@@ -229,8 +229,8 @@ bool half_bridge_enabled()
  * possible higher resolution yet.
  */
 
-#include <stm32_ll_system.h>
 #include <stm32_ll_bus.h>
+#include <stm32_ll_system.h>
 
 static void tim_init_registers(int freq_kHz)
 {
@@ -242,7 +242,8 @@ static void tim_init_registers(int freq_kHz)
     HRTIM1->sCommonRegs.DLLCR |= HRTIM_DLLCR_CALEN | HRTIM_DLLCR_CALRTE_0 | HRTIM_DLLCR_CALRTE_1;
 
     // Wait for calibration to finish
-    while ((HRTIM1_COMMON->ISR & HRTIM_ISR_DLLRDY) == 0) {;}
+    while ((HRTIM1_COMMON->ISR & HRTIM_ISR_DLLRDY) == 0) {
+    }
 
     // Prescaler 32 --> SystemClock (same as normal timers like TIM1)
     HRTIM1_TIMA->TIMxCR |= (5U << HRTIM_TIMCR_CK_PSC_Pos);
@@ -254,10 +255,10 @@ static void tim_init_registers(int freq_kHz)
     HRTIM1_TIMA->TIMxCR |= HRTIM_TIMCR_CONT;
 
     // Enable preloading with timer reset update trigger
-    //HRTIM1_TIMA->TIMxCR |= HRTIM_TIMCR_PREEN | HRTIM_TIMCR_TRSTU;
+    // HRTIM1_TIMA->TIMxCR |= HRTIM_TIMCR_PREEN | HRTIM_TIMCR_TRSTU;
 
     // Enable preloading with timer E update trigger
-    //HRTIM1_TIMA->TIMxCR |= HRTIM_TIMCR_PREEN | HRTIM_TIMCR_TEU;
+    // HRTIM1_TIMA->TIMxCR |= HRTIM_TIMCR_PREEN | HRTIM_TIMCR_TEU;
 
     // Timer period register
     HRTIM1_TIMA->PERxR = SystemCoreClock / (freq_kHz * 1000) + 1;
@@ -269,11 +270,10 @@ static void tim_init_registers(int freq_kHz)
 
     // Set deadtime values and lock deadtime signs
     HRTIM1_TIMA->DTxR |=
-        HRTIM_DTR_DTFSLK | (tim_dt_clocks << 16U) |
-        HRTIM_DTR_DTRSLK | tim_dt_clocks;
+        HRTIM_DTR_DTFSLK | (tim_dt_clocks << 16U) | HRTIM_DTR_DTRSLK | tim_dt_clocks;
 
     // activate trigger for ADC
-    HRTIM1_COMMON->CR1 = HRTIM_CR1_ADC1USRC_0; // ADC trigger update: Timer A
+    HRTIM1_COMMON->CR1 = HRTIM_CR1_ADC1USRC_0;  // ADC trigger update: Timer A
     HRTIM1_COMMON->ADC1R = HRTIM_ADC1R_AD1TAC3; // ADC trigger event: Timer A compare 3
 
     // Start timer A
@@ -354,7 +354,7 @@ uint16_t half_bridge_get_ccr()
 
 void half_bridge_set_ccr(uint16_t ccr)
 {
-    tim_ccr = clamp_ccr(ccr);          // high-side
+    tim_ccr = clamp_ccr(ccr); // high-side
 }
 
 bool half_bridge_enabled()
@@ -381,7 +381,7 @@ void half_bridge_init(int freq_kHz, int deadtime_ns, float min_duty, float max_d
     tim_ccr_min = min_duty * half_bridge_get_arr();
     tim_ccr_max = max_duty * half_bridge_get_arr();
 
-    half_bridge_set_duty_cycle(max_duty);      // init with allowed value
+    half_bridge_set_duty_cycle(max_duty); // init with allowed value
 }
 
 void half_bridge_set_duty_cycle(float duty)

--- a/app/src/hardware.cpp
+++ b/app/src/hardware.cpp
@@ -6,11 +6,11 @@
 
 #include "hardware.h"
 
-#include "mcu.h"
-#include "load.h"
-#include "helper.h"
 #include "half_bridge.h"
+#include "helper.h"
 #include "leds.h"
+#include "load.h"
+#include "mcu.h"
 #include "setup.h"
 
 #ifndef UNIT_TEST
@@ -19,8 +19,8 @@
 #define BOOT0_GPIO DT_CHILD(DT_PATH(outputs), boot0)
 #endif
 
-#include <power/reboot.h>
 #include <drivers/gpio.h>
+#include <power/reboot.h>
 
 LOG_MODULE_REGISTER(hardware, CONFIG_HW_LOG_LEVEL);
 
@@ -30,9 +30,9 @@ void start_stm32_bootloader()
     // pin is connected to BOOT0 via resistor and capacitor
     const struct device *dev = device_get_binding(DT_GPIO_LABEL(BOOT0_GPIO, gpios));
     gpio_pin_configure(dev, DT_GPIO_PIN(BOOT0_GPIO, gpios),
-        DT_GPIO_FLAGS(BOOT0_GPIO, gpios) | GPIO_OUTPUT_ACTIVE);
+                       DT_GPIO_FLAGS(BOOT0_GPIO, gpios) | GPIO_OUTPUT_ACTIVE);
 
-    k_sleep(K_MSEC(100));   // wait for capacitor at BOOT0 pin to charge up
+    k_sleep(K_MSEC(100)); // wait for capacitor at BOOT0 pin to charge up
     reset_device();
 #elif defined(CONFIG_SOC_SERIES_STM32G4X)
     if ((FLASH->CR & FLASH_CR_OPTLOCK) != 0U) {
@@ -75,12 +75,12 @@ void reset_device()
 
 void task_wdt_callback(int channel_id, void *user_data)
 {
-	printk("Task watchdog callback (channel: %d, thread: %s)\n",
-		channel_id, k_thread_name_get((k_tid_t)user_data));
+    printk("Task watchdog callback (channel: %d, thread: %s)\n", channel_id,
+           k_thread_name_get((k_tid_t)user_data));
 
-	printk("Resetting device...\n");
+    printk("Resetting device...\n");
 
-	sys_reboot(SYS_REBOOT_COLD);
+    sys_reboot(SYS_REBOOT_COLD);
 }
 
 #else

--- a/app/src/helper.h
+++ b/app/src/helper.h
@@ -13,8 +13,8 @@
  * General helper functions
  */
 
-#include <string.h>
 #include <stdint.h>
+#include <string.h>
 #include <time.h>
 
 #ifdef __INTELLISENSE__
@@ -65,7 +65,10 @@ static inline uint32_t uptime()
  * @param field pointer to the field that will be manipulated
  * @param mask a single flag or bitwise OR-ed flags
  */
-inline void flags_set(uint32_t *field, uint32_t mask) { *field |= mask; }
+inline void flags_set(uint32_t *field, uint32_t mask)
+{
+    *field |= mask;
+}
 
 /**
  * Clears one or more flags in the bit field
@@ -73,7 +76,10 @@ inline void flags_set(uint32_t *field, uint32_t mask) { *field |= mask; }
  * @param field pointer to the field that will be manipulated
  * @param mask a single flag or bitwise OR-ed flags
  */
-inline void flags_clear(uint32_t *field, uint32_t mask) { *field &= ~mask; }
+inline void flags_clear(uint32_t *field, uint32_t mask)
+{
+    *field &= ~mask;
+}
 
 /**
  * Queries one or more flags in the bit field
@@ -82,7 +88,10 @@ inline void flags_clear(uint32_t *field, uint32_t mask) { *field &= ~mask; }
  * @param mask a single flag or bitwise OR-ed
  * @returns true if any of the flags given in mask are set in the bit field
  */
-inline bool flags_check(uint32_t *field, uint32_t mask) { return (*field & mask) != 0; }
+inline bool flags_check(uint32_t *field, uint32_t mask)
+{
+    return (*field & mask) != 0;
+}
 
 #ifdef __cplusplus
 }

--- a/app/src/leds.cpp
+++ b/app/src/leds.cpp
@@ -6,13 +6,13 @@
 
 #include "leds.h"
 
-#include <zephyr.h>
 #include <drivers/gpio.h>
 #include <task_wdt/task_wdt.h>
+#include <zephyr.h>
 
 #include "hardware.h"
 
-#define SLEEP_TIME_MS 	(1000/60/NUM_LEDS)		// 60 Hz
+#define SLEEP_TIME_MS (1000 / 60 / NUM_LEDS) // 60 Hz
 
 /*
  * The LED setup is derived from the devicetree configuration in board.dts file
@@ -59,9 +59,8 @@
  * };
  */
 #define LED_STATES(node_id) DT_PROP(node_id, states),
-static const int led_pin_states[NUM_LEDS][NUM_LED_PINS] = {
-    DT_FOREACH_CHILD(DT_PATH(leds), LED_STATES)
-};
+static const int led_pin_states[NUM_LEDS][NUM_LED_PINS] = { DT_FOREACH_CHILD(DT_PATH(leds),
+                                                                             LED_STATES) };
 
 /*
  * GPIO pin numbers (for up to 5 LED pins)
@@ -120,10 +119,10 @@ static const gpio_flags_t led_flags[] = {
 #endif
 };
 
-static int led_states[NUM_LEDS];                // must be one of enum LedState
-static int trigger_timeout[NUM_LEDS];           // seconds until trigger should end
+static int led_states[NUM_LEDS];      // must be one of enum LedState
+static int trigger_timeout[NUM_LEDS]; // seconds until trigger should end
 
-static bool blink_state = true;                 // global state of all blinking LEDs
+static bool blink_state = true; // global state of all blinking LEDs
 
 static bool charging = false;
 
@@ -157,22 +156,21 @@ void leds_update_thread()
             flicker_state = !flicker_state;
         }
 
-        if (led_count < NUM_LEDS && (
-                led_states[led_count] == LED_STATE_ON ||
-                (led_states[led_count] == LED_STATE_FLICKER && flicker_state == 1) ||
-                (led_states[led_count] == LED_STATE_BLINK && blink_state == 1)
-            ))
+        if (led_count < NUM_LEDS
+            && (led_states[led_count] == LED_STATE_ON
+                || (led_states[led_count] == LED_STATE_FLICKER && flicker_state == 1)
+                || (led_states[led_count] == LED_STATE_BLINK && blink_state == 1)))
         {
             for (unsigned int pin_number = 0; pin_number < NUM_LED_PINS; pin_number++) {
                 switch (led_pin_states[led_count][pin_number]) {
                     case PIN_HIGH:
                         gpio_pin_configure(led_devs[pin_number], led_pins[pin_number],
-                            led_flags[pin_number] | GPIO_OUTPUT);
+                                           led_flags[pin_number] | GPIO_OUTPUT);
                         gpio_pin_set(led_devs[pin_number], led_pins[pin_number], 1);
                         break;
                     case PIN_LOW:
                         gpio_pin_configure(led_devs[pin_number], led_pins[pin_number],
-                            led_flags[pin_number] | GPIO_OUTPUT);
+                                           led_flags[pin_number] | GPIO_OUTPUT);
                         gpio_pin_set(led_devs[pin_number], led_pins[pin_number], 0);
                         break;
                     case PIN_FLOAT:
@@ -193,7 +191,7 @@ void leds_update_thread()
 
         k_sleep(K_MSEC(SLEEP_TIME_MS));
     }
-#endif  // UNIT_TEST
+#endif // UNIT_TEST
 }
 
 void leds_init(bool enabled)
@@ -201,7 +199,7 @@ void leds_init(bool enabled)
     for (unsigned int led = 0; led < NUM_LEDS; led++) {
         if (enabled) {
             led_states[led] = LED_STATE_ON;
-            trigger_timeout[led] = 0;      // switched off the first time the main loop is called
+            trigger_timeout[led] = 0; // switched off the first time the main loop is called
         }
         else {
             led_states[led] = LED_STATE_OFF;
@@ -287,7 +285,7 @@ void leds_update_soc(int soc, bool load_off_low_soc)
 #if LED_EXISTS(pwr)
     led_states[LED_POS(pwr)] = blink_chg;
     trigger_timeout[LED_POS(pwr)] = -1;
-#elif LED_EXISTS(soc_3)  // 3-bar SOC gauge
+#elif LED_EXISTS(soc_3) // 3-bar SOC gauge
     trigger_timeout[LED_POS(soc_1)] = -1;
     trigger_timeout[LED_POS(soc_2)] = -1;
     trigger_timeout[LED_POS(soc_3)] = -1;
@@ -310,5 +308,5 @@ void leds_update_soc(int soc, bool load_off_low_soc)
 }
 
 #ifndef UNIT_TEST
-K_THREAD_DEFINE(leds_thread, 256, leds_update_thread, NULL, NULL, NULL,	4, 0, 100);
+K_THREAD_DEFINE(leds_thread, 256, leds_update_thread, NULL, NULL, NULL, 4, 0, 100);
 #endif

--- a/app/src/leds.h
+++ b/app/src/leds.h
@@ -44,15 +44,17 @@ extern "C" {
  * Enum for numbering of LEDs in the order specified in board.dts
  */
 // cppcheck-suppress syntaxError
-enum {
-    DT_FOREACH_CHILD(DT_PATH(leds), LED_ENUM)
-    NUM_LEDS          // trick to get the number of elements
+enum
+{
+    DT_FOREACH_CHILD(DT_PATH(leds), LED_ENUM) // actual LED nodes
+    NUM_LEDS                                  // trick to get the number of nodes
 };
 
 /**
  * LED states
  */
-enum LedState {
+enum LedState
+{
     LED_STATE_OFF = 0,
     LED_STATE_ON,
     LED_STATE_BLINK,
@@ -62,7 +64,8 @@ enum LedState {
 /**
  * Pin states
  */
-enum PinState {
+enum PinState
+{
     PIN_LOW = 0,
     PIN_HIGH,
     PIN_FLOAT

--- a/app/src/load.h
+++ b/app/src/load.h
@@ -13,8 +13,8 @@
  * Load/USB output functions and data types
  */
 
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <time.h>
 
 #ifdef __cplusplus
@@ -24,18 +24,19 @@
 /**
  * Load/USB output states
  */
-enum LoadState {
-    LOAD_STATE_OFF = 0,             ///< Actively disabled
-    LOAD_STATE_ON = 1,              ///< Normal state: On
+enum LoadState
+{
+    LOAD_STATE_OFF = 0, ///< Actively disabled
+    LOAD_STATE_ON = 1,  ///< Normal state: On
 };
-
 
 /** Load error flags
  *
  * When adding new flags, please make sure to use only up to 32 errors
  * Each enum must represent a unique power of 2 number
  */
-enum LoadErrorFlag {
+enum LoadErrorFlag
+{
     /**
      * Available energy or power too low
      *
@@ -93,7 +94,8 @@ class LoadOutput : public PowerPort
 {
 public:
     /**
-     * Initialize LoadOutput struct and overcurrent / short circuit protection comparator (if existing)
+     * Initialize LoadOutput struct and overcurrent / short circuit protection comparator (if
+     * existing)
      *
      * @param dc_bus DC bus the load is connected to
      * @param switch_fn Pointer to function for enabling/disabling load switch
@@ -125,33 +127,33 @@ public:
      */
     void set_voltage_limits(float lvd, float lvr, float ov);
 
-    uint32_t state;             ///< Current state of load output switch
+    uint32_t state; ///< Current state of load output switch
 
-    uint32_t error_flags = 0;   ///< Stores error flags as bits according to LoadErrorFlag enum
+    uint32_t error_flags = 0; ///< Stores error flags as bits according to LoadErrorFlag enum
 
-    int32_t info;               ///< Contains either the state or negative value of error_flags
-                                ///< in case of error_flags > 0. This allows to have a single
-                                ///< variable for load state diagnosis.
+    int32_t info; ///< Contains either the state or negative value of error_flags
+                  ///< in case of error_flags > 0. This allows to have a single
+                  ///< variable for load state diagnosis.
 
-    bool enable = false;        ///< Target on state set via communication port (overruled if
-                                ///< battery is empty or any errors occured)
+    bool enable = false; ///< Target on state set via communication port (overruled if
+                         ///< battery is empty or any errors occured)
 
     time_t oc_timestamp;        ///< Time when last overcurrent event occured
     uint32_t oc_recovery_delay; ///< Seconds before we attempt to re-enable the load
                                 ///< after an overcurrent event
 
-    float disconnect_voltage = 0;   ///< Low voltage disconnect (LVD) setpoint
-    float reconnect_voltage = 0;    ///< Low voltage reconnect (LVD) setpoint
+    float disconnect_voltage = 0; ///< Low voltage disconnect (LVD) setpoint
+    float reconnect_voltage = 0;  ///< Low voltage reconnect (LVD) setpoint
 
-    time_t lvd_timestamp;       ///< Time when last low voltage disconnect happened
-    uint32_t lvd_recovery_delay;///< Seconds before we re-enable the load after a low voltage
-                                ///< disconnect
+    time_t lvd_timestamp;        ///< Time when last low voltage disconnect happened
+    uint32_t lvd_recovery_delay; ///< Seconds before we re-enable the load after a low voltage
+                                 ///< disconnect
 
     float junction_temperature; ///< calculated using thermal model based on current and ambient
                                 ///< temperature measurement (unit: °C)
 
-    float overvoltage = 0;      ///< Upper voltage limit
-    float ov_hysteresis;        ///< Hysteresis to switch back on after an overvoltage event
+    float overvoltage = 0; ///< Upper voltage limit
+    float ov_hysteresis;   ///< Hysteresis to switch back on after an overvoltage event
 
 private:
     /**
@@ -175,7 +177,6 @@ private:
     int ov_debounce_counter = 0;
 };
 #endif
-
 
 #ifdef __cplusplus
 extern "C" {

--- a/app/src/load_driver.c
+++ b/app/src/load_driver.c
@@ -8,18 +8,18 @@
 
 #ifdef CONFIG_SOC_FAMILY_STM32
 
-#include <zephyr.h>
 #include <device.h>
 #include <drivers/gpio.h>
 #include <drivers/pwm.h>
+#include <zephyr.h>
 
 #include "board.h"
 #include "hardware.h"
 #include "leds.h"
 #include "mcu.h"
 
-#include <stm32_ll_system.h>
 #include <stm32_ll_bus.h>
+#include <stm32_ll_system.h>
 
 #if BOARD_HAS_LOAD_OUTPUT
 #define LOAD_GPIO DT_CHILD(DT_PATH(outputs), load)
@@ -55,7 +55,7 @@ static void lptim_init()
     // Select trigger 7 (COMP2_OUT)
     LPTIM1->CFGR |= 0x7U << LPTIM_CFGR_TRIGSEL_Pos;
 
-    //LPTIM1->CFGR |= LPTIM_CFGR_WAVPOL;
+    // LPTIM1->CFGR |= LPTIM_CFGR_WAVPOL;
     LPTIM1->CFGR |= LPTIM_CFGR_PRELOAD;
 
     // Glitch filter of 8 cycles
@@ -76,8 +76,8 @@ static void lptim_init()
     LPTIM1->CMP = 10;
 
     // Continuous mode
-    //LPTIM1->CR |= LPTIM_CR_CNTSTRT;
-    //LPTIM1->CR |= LPTIM_CR_SNGSTRT;
+    // LPTIM1->CR |= LPTIM_CR_CNTSTRT;
+    // LPTIM1->CR |= LPTIM_CR_SNGSTRT;
 }
 
 void ADC1_COMP_IRQHandler(void *args)
@@ -115,11 +115,11 @@ void short_circuit_comp_init()
     COMP2->CSR |= COMP_CSR_COMP2LPTIM1IN1;
 
     // normal polarity
-    //COMP2->CSR |= COMP_CSR_COMP2POLARITY;
+    // COMP2->CSR |= COMP_CSR_COMP2POLARITY;
 
     // set high-speed mode (1.2us instead of 2.5us propagation delay, but 3.5uA instead of 0.5uA
     // current consumption)
-    //COMP2->CSR |= COMP_CSR_COMP2SPEED;
+    // COMP2->CSR |= COMP_CSR_COMP2SPEED;
 
     // enable COMP2
     COMP2->CSR |= COMP_CSR_COMP2EN;
@@ -146,7 +146,7 @@ void load_out_set(bool status)
 
 #if BOARD_HAS_LOAD_OUTPUT
     gpio_pin_configure(dev_load, DT_GPIO_PIN(LOAD_GPIO, gpios),
-        DT_GPIO_FLAGS(LOAD_GPIO, gpios) | GPIO_OUTPUT_INACTIVE);
+                       DT_GPIO_FLAGS(LOAD_GPIO, gpios) | GPIO_OUTPUT_INACTIVE);
     if (status == true) {
 #ifdef CONFIG_BOARD_PWM_2420_LUS
         lptim_init();
@@ -164,7 +164,7 @@ void usb_out_set(bool status)
 {
 #if BOARD_HAS_USB_OUTPUT
     gpio_pin_configure(dev_usb, DT_GPIO_PIN(USB_GPIO, gpios),
-        DT_GPIO_FLAGS(USB_GPIO, gpios) | GPIO_OUTPUT_INACTIVE);
+                       DT_GPIO_FLAGS(USB_GPIO, gpios) | GPIO_OUTPUT_INACTIVE);
     if (status == true) {
         gpio_pin_set(dev_usb, DT_GPIO_PIN(USB_GPIO, gpios), 1);
 #if DT_PROP(DT_CHILD(DT_PATH(outputs), usb_pwr), latching_pgood)
@@ -180,18 +180,18 @@ void usb_out_set(bool status)
 
 #if DT_NODE_EXISTS(DT_CHILD(DT_PATH(outputs), charge_pump))
 
-#define CP_PWMS             DT_CHILD(DT_PATH(outputs), charge_pump)
-#define CP_PWM_CONTROLLER   DT_PWMS_CTLR(CP_PWMS)
-#define CP_PWM_PERIOD       DT_PWMS_PERIOD(CP_PWMS)
-#define CP_PWM_CHANNEL      DT_PWMS_CHANNEL(CP_PWMS)
+#define CP_PWMS           DT_CHILD(DT_PATH(outputs), charge_pump)
+#define CP_PWM_CONTROLLER DT_PWMS_CTLR(CP_PWMS)
+#define CP_PWM_PERIOD     DT_PWMS_PERIOD(CP_PWMS)
+#define CP_PWM_CHANNEL    DT_PWMS_CHANNEL(CP_PWMS)
 
 void load_cp_enable()
 {
-	const struct device *pwm_dev = DEVICE_DT_GET(CP_PWM_CONTROLLER);
-	if (device_is_ready(pwm_dev)) {
+    const struct device *pwm_dev = DEVICE_DT_GET(CP_PWM_CONTROLLER);
+    if (device_is_ready(pwm_dev)) {
         // set to 50% duty cycle
         pwm_pin_set_nsec(pwm_dev, CP_PWM_CHANNEL, CP_PWM_PERIOD, CP_PWM_PERIOD / 2, 0);
-	}
+    }
 }
 
 #endif
@@ -231,12 +231,17 @@ bool pgood_check()
 
 #else // CONFIG_SOC_FAMILY_STM32
 
-void load_out_init() {;}
-void usb_out_init() {;}
+void load_out_init() {}
 
-void load_out_set(bool value) {;}
-void usb_out_set(bool value) {;}
+void usb_out_init() {}
 
-bool pgood_check() { return false; }
+void load_out_set(bool value) {}
+
+void usb_out_set(bool value) {}
+
+bool pgood_check()
+{
+    return false;
+}
 
 #endif

--- a/app/src/mcu.h
+++ b/app/src/mcu.h
@@ -24,33 +24,41 @@
 // factory calibration values for internal voltage reference and temperature sensor
 // (see MCU datasheet, not Reference Manual)
 #if defined(CONFIG_SOC_SERIES_STM32F0X)
-    #define VREFINT_CAL (*((uint16_t *)0x1FFFF7BA)) // VREFINT @3.3V/30°C
-    #define VREFINT_VALUE 3300 // mV
-    #define TSENSE_CAL1 (*((uint16_t *)0x1FFFF7B8))
-    #define TSENSE_CAL2 (*((uint16_t *)0x1FFFF7C2))
-    #define TSENSE_CAL1_VALUE 30.0   // temperature of first calibration point
-    #define TSENSE_CAL2_VALUE 110.0  // temperature of second calibration point
+
+#define VREFINT_CAL       (*((uint16_t *)0x1FFFF7BA)) // VREFINT @3.3V/30°C
+#define VREFINT_VALUE     3300                        // mV
+#define TSENSE_CAL1       (*((uint16_t *)0x1FFFF7B8))
+#define TSENSE_CAL2       (*((uint16_t *)0x1FFFF7C2))
+#define TSENSE_CAL1_VALUE 30.0  // temperature of first calibration point
+#define TSENSE_CAL2_VALUE 110.0 // temperature of second calibration point
+
 #elif defined(CONFIG_SOC_SERIES_STM32L0X)
-    #define VREFINT_CAL (*((uint16_t *)0x1FF80078))   // VREFINT @3.0V/25°C
-    #define VREFINT_VALUE 3000 // mV
-    #define TSENSE_CAL1 (*((uint16_t *)0x1FF8007A))
-    #define TSENSE_CAL2 (*((uint16_t *)0x1FF8007E))
-    #define TSENSE_CAL1_VALUE 30.0   // temperature of first calibration point
-    #define TSENSE_CAL2_VALUE 130.0  // temperature of second calibration point
+
+#define VREFINT_CAL       (*((uint16_t *)0x1FF80078)) // VREFINT @3.0V/25°C
+#define VREFINT_VALUE     3000                        // mV
+#define TSENSE_CAL1       (*((uint16_t *)0x1FF8007A))
+#define TSENSE_CAL2       (*((uint16_t *)0x1FF8007E))
+#define TSENSE_CAL1_VALUE 30.0  // temperature of first calibration point
+#define TSENSE_CAL2_VALUE 130.0 // temperature of second calibration point
+
 #elif defined(CONFIG_SOC_SERIES_STM32G4X)
-    #define VREFINT_CAL (*((uint16_t *)0x1FFF75AA))   // VREFINT @3.0V/30°C
-    #define VREFINT_VALUE 3000 // mV
-    #define TSENSE_CAL1 (*((uint16_t *)0x1FFF75A8))
-    #define TSENSE_CAL2 (*((uint16_t *)0x1FFF75CA))
-    #define TSENSE_CAL1_VALUE 30.0   // temperature of first calibration point
-    #define TSENSE_CAL2_VALUE 110.0  // temperature of second calibration point
+
+#define VREFINT_CAL       (*((uint16_t *)0x1FFF75AA)) // VREFINT @3.0V/30°C
+#define VREFINT_VALUE     3000                        // mV
+#define TSENSE_CAL1       (*((uint16_t *)0x1FFF75A8))
+#define TSENSE_CAL2       (*((uint16_t *)0x1FFF75CA))
+#define TSENSE_CAL1_VALUE 30.0  // temperature of first calibration point
+#define TSENSE_CAL2_VALUE 110.0 // temperature of second calibration point
+
 #elif !defined(CONFIG_SOC_FAMILY_STM32)
-    #define VREFINT_CAL (4096 * 1.224 / 3.0)   // VREFINT @3.0V/25°C
-    #define VREFINT_VALUE 3000 // mV
-    #define TSENSE_CAL1 (4096.0 * (670 - 161) / 3300)     // datasheet: slope 1.61 mV/°C
-    #define TSENSE_CAL2 (4096.0 * 670 / 3300)     // datasheet: 670 mV
-    #define TSENSE_CAL1_VALUE 30.0   // temperature of first calibration point
-    #define TSENSE_CAL2_VALUE 130.0  // temperature of second calibration point
+
+#define VREFINT_CAL       (4096 * 1.224 / 3.0)          // VREFINT @3.0V/25°C
+#define VREFINT_VALUE     3000                          // mV
+#define TSENSE_CAL1       (4096.0 * (670 - 161) / 3300) // datasheet: slope 1.61 mV/°C
+#define TSENSE_CAL2       (4096.0 * 670 / 3300)         // datasheet: 670 mV
+#define TSENSE_CAL1_VALUE 30.0                          // temperature of first calibration point
+#define TSENSE_CAL2_VALUE 130.0                         // temperature of second calibration point
+
 #endif
 
 #endif // MCU_H_

--- a/app/src/power_port.cpp
+++ b/app/src/power_port.cpp
@@ -8,8 +8,8 @@
 
 void PowerPort::init_solar()
 {
-    neg_current_limit = -50;    // derating based on max. DC/DC or PWM switch current only
-    pos_current_limit = 0;      // no current towards solar panel allowed
+    neg_current_limit = -50; // derating based on max. DC/DC or PWM switch current only
+    pos_current_limit = 0;   // no current towards solar panel allowed
 }
 
 void PowerPort::init_nanogrid()
@@ -22,8 +22,8 @@ void PowerPort::init_nanogrid()
     bus->src_droop_res = 0.1;
 
     // also initialize the connected bus
-    bus->src_voltage_intercept = 30.0;          // starting buck mode above this point
-    bus->sink_voltage_intercept = 28.0;         // boost mode until this voltage is reached
+    bus->src_voltage_intercept = 30.0;  // starting buck mode above this point
+    bus->sink_voltage_intercept = 28.0; // boost mode until this voltage is reached
 }
 
 void PowerPort::energy_balance()
@@ -45,5 +45,5 @@ void PowerPort::update_bus_current_margins() const
     // discharging direction of battery
     bus->src_current_margin = neg_current_limit - current;
 
-    //printf("pos: %.3f neg: %.3f current: %.3f\n", pos_current_limit, neg_current_limit, current);
+    // printf("pos: %.3f neg: %.3f current: %.3f\n", pos_current_limit, neg_current_limit, current);
 }

--- a/app/src/power_port.h
+++ b/app/src/power_port.h
@@ -12,11 +12,11 @@
  * @brief Definition of charge controller terminals and internal DC buses
  */
 
-#include <stdint.h>
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
-class PowerPort;    // forward-declaration
+class PowerPort; // forward-declaration
 
 /**
  * DC bus class
@@ -231,8 +231,7 @@ public:
      * @param assign_ref_current defines if the bus ref_current should point to the current
      *                           of this port (must be true for at least one port)
      */
-    PowerPort(DcBus *dc_bus, bool assign_ref_current = false) :
-        bus(dc_bus)
+    PowerPort(DcBus *dc_bus, bool assign_ref_current = false) : bus(dc_bus)
     {
         if (assign_ref_current) {
             bus->ref_current = &current;

--- a/app/src/pwm_switch.cpp
+++ b/app/src/pwm_switch.cpp
@@ -11,9 +11,9 @@
 #include <stdio.h>
 #include <time.h>
 
-#include "mcu.h"
 #include "daq.h"
 #include "helper.h"
+#include "mcu.h"
 #include "setup.h"
 
 LOG_MODULE_REGISTER(pwm_switch, CONFIG_PWM_LOG_LEVEL);
@@ -21,7 +21,7 @@ LOG_MODULE_REGISTER(pwm_switch, CONFIG_PWM_LOG_LEVEL);
 #if BOARD_HAS_PWM_PORT
 
 #define PWM_CURRENT_MAX (DT_PROP(DT_CHILD(DT_PATH(outputs), pwm_switch), current_max))
-#define PWM_PERIOD (DT_PHA(DT_CHILD(DT_PATH(outputs), pwm_switch), pwms, period))
+#define PWM_PERIOD      (DT_PHA(DT_CHILD(DT_PATH(outputs), pwm_switch), pwms, period))
 
 bool PwmSwitch::active()
 {
@@ -33,8 +33,7 @@ bool PwmSwitch::signal_high()
     return pwm_signal_high();
 }
 
-PwmSwitch::PwmSwitch(DcBus *dc_bus) :
-    PowerPort(dc_bus)
+PwmSwitch::PwmSwitch(DcBus *dc_bus) : PowerPort(dc_bus)
 {
     // period stored in nanoseconds
     pwm_signal_init_registers(1000 * 1000 * 1000 / PWM_PERIOD);
@@ -59,13 +58,12 @@ void PwmSwitch::control()
 {
     if (pwm_active()) {
         if (current < -0.1F) {
-            power_good_timestamp = uptime();     // reset the time
+            power_good_timestamp = uptime(); // reset the time
         }
 
-        if (neg_current_limit == 0
-            || (uptime() - power_good_timestamp > 10)      // low power since 10s
-            || current > 0.5F         // discharging battery into solar panel --> stop
-            || bus->voltage < 9.0F    // not enough voltage for MOSFET drivers anymore
+        if (neg_current_limit == 0 || (uptime() - power_good_timestamp > 10) // low power since 10s
+            || current > 0.5F      // discharging battery into solar panel --> stop
+            || bus->voltage < 9.0F // not enough voltage for MOSFET drivers anymore
             || enable == false)
         {
             pwm_signal_stop();
@@ -78,9 +76,9 @@ void PwmSwitch::control()
             dev_stat.set_error(ERR_PWM_SWITCH_OVERVOLTAGE);
             LOG_INF("PWM charger stop, overvoltage.");
         }
-        else if (bus->voltage > bus->sink_control_voltage()   // bus voltage above target
-            || current < neg_current_limit                    // port current limit exceeded
-            || current < -PWM_CURRENT_MAX)                    // PCB current limit exceeded
+        else if (bus->voltage > bus->sink_control_voltage() // bus voltage above target
+                 || current < neg_current_limit             // port current limit exceeded
+                 || current < -PWM_CURRENT_MAX)             // PCB current limit exceeded
         {
             // decrease power, as limits were reached
 
@@ -116,18 +114,17 @@ void PwmSwitch::control()
             }
         }
 
-        if (dev_stat.has_error(ERR_PWM_SWITCH_OVERVOLTAGE) &&
-            bus->voltage < bus->sink_control_voltage() - 0.5F)
+        if (dev_stat.has_error(ERR_PWM_SWITCH_OVERVOLTAGE)
+            && bus->voltage < bus->sink_control_voltage() - 0.5F)
         {
             dev_stat.clear_error(ERR_PWM_SWITCH_OVERVOLTAGE);
         }
     }
     else {
-        if (bus->sink_current_margin > 0          // charging allowed
-            && bus->voltage < bus->sink_control_voltage()
+        if (bus->sink_current_margin > 0 && // charging allowed
+            bus->voltage < bus->sink_control_voltage()
             && ext_voltage > bus->voltage + offset_voltage_start
-            && uptime() > (off_timestamp + restart_interval)
-            && enable == true)
+            && uptime() > (off_timestamp + restart_interval) && enable == true)
         {
             // turning the PWM switch on creates a short voltage rise, so inhibit alerts by 50 ms
             adc_upper_alert_inhibit(ADC_POS(v_low), 50);

--- a/app/src/pwm_switch.h
+++ b/app/src/pwm_switch.h
@@ -139,7 +139,7 @@ void pwm_signal_duty_cycle_step(int delta);
  * cycle limits
  *
  * @param freq_Hz Switching frequency in Hz
-*/
+ */
 void pwm_signal_init_registers(int freq_Hz);
 
 /**

--- a/app/src/pwm_switch_driver.c
+++ b/app/src/pwm_switch_driver.c
@@ -20,12 +20,12 @@
 
 #ifndef UNIT_TEST
 
-#include <stm32_ll_tim.h>
-#include <stm32_ll_rcc.h>
 #include <stm32_ll_bus.h>
+#include <stm32_ll_rcc.h>
+#include <stm32_ll_tim.h>
 
-#include <soc.h>
 #include <pinmux/pinmux_stm32.h>
+#include <soc.h>
 
 #define DT_DRV_COMPAT st_stm32_pwm
 
@@ -33,19 +33,19 @@
 static TIM_TypeDef *tim = TIM3;
 
 #if DT_PWMS_CHANNEL(DT_CHILD(DT_PATH(outputs), pwm_switch)) == 1
-#define LL_TIM_CHANNEL LL_TIM_CHANNEL_CH1
+#define LL_TIM_CHANNEL       LL_TIM_CHANNEL_CH1
 #define LL_TIM_OC_SetCompare LL_TIM_OC_SetCompareCH1
 #define LL_TIM_OC_GetCompare LL_TIM_OC_GetCompareCH1
 #elif DT_PWMS_CHANNEL(DT_CHILD(DT_PATH(outputs), pwm_switch)) == 2
-#define LL_TIM_CHANNEL LL_TIM_CHANNEL_CH2
+#define LL_TIM_CHANNEL       LL_TIM_CHANNEL_CH2
 #define LL_TIM_OC_SetCompare LL_TIM_OC_SetCompareCH2
 #define LL_TIM_OC_GetCompare LL_TIM_OC_GetCompareCH2
 #elif DT_PWMS_CHANNEL(DT_CHILD(DT_PATH(outputs), pwm_switch)) == 3
-#define LL_TIM_CHANNEL LL_TIM_CHANNEL_CH3
+#define LL_TIM_CHANNEL       LL_TIM_CHANNEL_CH3
 #define LL_TIM_OC_SetCompare LL_TIM_OC_SetCompareCH3
 #define LL_TIM_OC_GetCompare LL_TIM_OC_GetCompareCH3
 #elif DT_PWMS_CHANNEL(DT_CHILD(DT_PATH(outputs), pwm_switch)) == 4
-#define LL_TIM_CHANNEL LL_TIM_CHANNEL_CH4
+#define LL_TIM_CHANNEL       LL_TIM_CHANNEL_CH4
 #define LL_TIM_OC_SetCompare LL_TIM_OC_SetCompareCH4
 #define LL_TIM_OC_GetCompare LL_TIM_OC_GetCompareCH4
 #else
@@ -79,7 +79,7 @@ void pwm_signal_init_registers(int freq_Hz)
 {
     stm32_dt_pinctrl_configure(pwm_pinctrl, ARRAY_SIZE(pwm_pinctrl), (uint32_t)tim);
 
-	LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_TIM3);
+    LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_TIM3);
 
     // Set timer clock to 10 kHz
     LL_TIM_SetPrescaler(TIM3, SystemCoreClock / 10000 - 1);
@@ -151,14 +151,30 @@ bool pwm_active()
 #else
 
 // dummy functions for unit tests
-float pwm_signal_get_duty_cycle() { return 0; }
-void pwm_signal_set_duty_cycle(float duty) {;}
-void pwm_signal_duty_cycle_step(int delta) {;}
-void pwm_signal_init_registers(int freq_Hz) {;}
-void pwm_signal_start(float pwm_duty) {;}
-void pwm_signal_stop() {;}
-bool pwm_signal_high() { return false; }
-bool pwm_active() { return false; }
+float pwm_signal_get_duty_cycle()
+{
+    return 0;
+}
+
+void pwm_signal_set_duty_cycle(float duty) {}
+
+void pwm_signal_duty_cycle_step(int delta) {}
+
+void pwm_signal_init_registers(int freq_Hz) {}
+
+void pwm_signal_start(float pwm_duty) {}
+
+void pwm_signal_stop() {}
+
+bool pwm_signal_high()
+{
+    return false;
+}
+
+bool pwm_active()
+{
+    return false;
+}
 
 #endif
 

--- a/app/src/setup.cpp
+++ b/app/src/setup.cpp
@@ -11,27 +11,27 @@
 
 #include <zephyr.h>
 
-#include "thingset.h"           // handles access to internal data via communication interfaces
+#include "thingset.h" // handles access to internal data via communication interfaces
 
+#include "bat_charger.h" // battery settings and charger state machine
 #include "board.h"
-#include "half_bridge.h"        // PWM generation for DC/DC converter
-#include "hardware.h"           // hardware-related functions like load switch, LED control, watchdog, etc.
-#include "dcdc.h"               // DC/DC converter control (hardware independent)
-#include "pwm_switch.h"         // PWM charge controller
-#include "bat_charger.h"        // battery settings and charger state machine
-#include "daq.h"                // ADC using DMA and conversion to measurement values
-#include "data_storage.h"             // external I2C EEPROM
-#include "load.h"               // load and USB output management
-#include "leds.h"               // LED switching using charlieplexing
-#include "device_status.h"      // log data (error memory, min/max measurements, etc.)
-#include "data_objects.h"         // for access to internal data via ThingSet
+#include "daq.h"           // ADC using DMA and conversion to measurement values
+#include "data_objects.h"  // for access to internal data via ThingSet
+#include "data_storage.h"  // external I2C EEPROM
+#include "dcdc.h"          // DC/DC converter control (hardware independent)
+#include "device_status.h" // log data (error memory, min/max measurements, etc.)
+#include "half_bridge.h"   // PWM generation for DC/DC converter
+#include "hardware.h"   // hardware-related functions like load switch, LED control, watchdog, etc.
+#include "leds.h"       // LED switching using charlieplexing
+#include "load.h"       // load and USB output management
+#include "pwm_switch.h" // PWM charge controller
 
 DcBus lv_bus;
-PowerPort lv_terminal(&lv_bus, true);   // low voltage terminal (battery for typical MPPT)
+PowerPort lv_terminal(&lv_bus, true); // low voltage terminal (battery for typical MPPT)
 
 #if BOARD_HAS_DCDC
 DcBus hv_bus;
-PowerPort hv_terminal(&hv_bus, true);   // high voltage terminal (solar for typical MPPT)
+PowerPort hv_terminal(&hv_bus, true); // high voltage terminal (solar for typical MPPT)
 #if CONFIG_HV_TERMINAL_NANOGRID
 Dcdc dcdc(&hv_bus, &lv_bus, DCDC_MODE_AUTO);
 #elif CONFIG_HV_TERMINAL_BATTERY
@@ -73,8 +73,8 @@ PowerPort &bat_terminal = hv_terminal;
 
 Charger charger(&bat_terminal);
 
-BatConf bat_conf;               // actual (used) battery configuration
-BatConf bat_conf_user;          // temporary storage where the user can write to
+BatConf bat_conf;      // actual (used) battery configuration
+BatConf bat_conf_user; // temporary storage where the user can write to
 
 DeviceStatus dev_stat;
 
@@ -84,8 +84,8 @@ uint32_t timestamp;
 
 #ifndef UNIT_TEST
 
-#include <zephyr.h>
 #include <soc.h>
+#include <zephyr.h>
 
 static inline void timestamp_inc(struct k_timer *timer_id)
 {

--- a/app/src/setup.h
+++ b/app/src/setup.h
@@ -9,12 +9,12 @@
 #include <stdio.h>
 
 #include "bat_charger.h"
+#include "board.h"
 #include "device_status.h"
 #include "load.h"
 #include "power_port.h"
 #include "pwm_switch.h"
 #include "thingset.h"
-#include "board.h"
 
 extern DcBus lv_bus;
 extern PowerPort lv_terminal;
@@ -46,7 +46,7 @@ extern LoadOutput load;
 extern LoadOutput usb_pwr;
 #endif
 
-extern ThingSet ts;             // defined in data_objects.cpp
+extern ThingSet ts; // defined in data_objects.cpp
 
 extern uint32_t timestamp;
 

--- a/tests/src/daq_stub.h
+++ b/tests/src/daq_stub.h
@@ -9,7 +9,8 @@
 
 /** Data to fill adc_filtered array during unit-tests
  */
-typedef struct {
+typedef struct
+{
     float solar_voltage;
     float battery_voltage;
     float dcdc_current;

--- a/tests/src/main.cpp
+++ b/tests/src/main.cpp
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <stdio.h>
 #include "unity.h"
+#include <stdio.h>
 
-#include <zephyr.h>
 #include <device.h>
+#include <zephyr.h>
 
 #ifdef CONFIG_ARCH_POSIX
 #include "posix_board_if.h"
@@ -18,8 +18,8 @@
 
 extern "C" {
 
-void setUp (void) {}
-void tearDown (void) {}
+void setUp(void) {}
+void tearDown(void) {}
 
 } /* extern "C" */
 

--- a/tests/src/tests.h
+++ b/tests/src/tests.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <unity.h>
 #include <time.h>
+#include <unity.h>
 
 int bat_charger_tests();
 

--- a/tests/src/tests_bat_charger.cpp
+++ b/tests/src/tests_bat_charger.cpp
@@ -6,8 +6,8 @@
 
 #include "tests.h"
 
-#include <time.h>
 #include <stdio.h>
+#include <time.h>
 
 #include "setup.h"
 
@@ -100,8 +100,8 @@ void stop_topping_after_time_limit()
     charger.target_voltage_timer = bat_conf.topping_duration - 1;
     bat_terminal.current = bat_conf.topping_cutoff_current + 0.1;
     bat_terminal.current_filtered = bat_terminal.current;
-    bat_terminal.bus->voltage = bat_conf.topping_voltage -
-        bat_terminal.current * bat_terminal.bus->sink_droop_res + 0.1;
+    bat_terminal.bus->voltage =
+        bat_conf.topping_voltage - bat_terminal.current * bat_terminal.bus->sink_droop_res + 0.1;
     bat_terminal.bus->voltage_filtered = bat_terminal.bus->voltage;
 
     charger.charge_control(&bat_conf);
@@ -119,8 +119,8 @@ void stop_topping_at_cutoff_current()
     charger.target_voltage_timer = 0;
     bat_terminal.current = bat_conf.topping_cutoff_current - 0.1;
     bat_terminal.current_filtered = bat_terminal.current;
-    bat_terminal.bus->voltage = bat_conf.topping_voltage -
-        bat_terminal.current * bat_terminal.bus->sink_droop_res + 0.1;
+    bat_terminal.bus->voltage =
+        bat_conf.topping_voltage - bat_terminal.current * bat_terminal.bus->sink_droop_res + 0.1;
     bat_terminal.bus->voltage_filtered = bat_terminal.bus->voltage;
     charger.charge_control(&bat_conf);
     TEST_ASSERT_EQUAL(CHG_STATE_FLOAT, charger.state);
@@ -133,8 +133,8 @@ void float_to_idle_for_li_ion()
 
     charger.time_state_changed = time(NULL) - 1;
     bat_terminal.current = bat_conf.topping_cutoff_current - 0.1;
-    bat_terminal.bus->voltage = bat_conf.topping_voltage -
-        bat_terminal.current * bat_terminal.bus->sink_droop_res + 0.1;
+    bat_terminal.bus->voltage =
+        bat_conf.topping_voltage - bat_terminal.current * bat_terminal.bus->sink_droop_res + 0.1;
     charger.charge_control(&bat_conf);
     TEST_ASSERT_EQUAL(CHG_STATE_IDLE, charger.state);
 }
@@ -147,8 +147,7 @@ void no_equalization_if_disabled()
     // set triggers such that it would normally start
     charger.deep_dis_last_equalization =
         charger.num_deep_discharges - bat_conf.equalization_trigger_deep_cycles;
-    charger.time_last_equalization =
-        time(NULL) - bat_conf.equalization_trigger_days * 24*60*60;
+    charger.time_last_equalization = time(NULL) - bat_conf.equalization_trigger_days * 24 * 60 * 60;
 
     charger.time_state_changed = time(NULL) - 1;
     bat_terminal.bus->voltage = bat_conf.topping_voltage + 0.1;
@@ -166,7 +165,7 @@ void no_equalization_if_limits_not_reached()
     charger.deep_dis_last_equalization =
         charger.num_deep_discharges - bat_conf.equalization_trigger_deep_cycles + 1;
     charger.time_last_equalization =
-        time(NULL) - (bat_conf.equalization_trigger_days - 1) * 24*60*60;
+        time(NULL) - (bat_conf.equalization_trigger_days - 1) * 24 * 60 * 60;
 
     charger.time_state_changed = time(NULL) - 1;
     bat_terminal.bus->voltage = bat_conf.topping_voltage + 0.1;
@@ -179,17 +178,15 @@ void float_to_equalization_if_enabled_and_time_limit_reached()
 {
     enter_topping_at_voltage_setpoint();
     bat_conf.equalization_enabled = true;
-    charger.time_last_equalization =
-        time(NULL) - bat_conf.equalization_trigger_days * 24*60*60;
+    charger.time_last_equalization = time(NULL) - bat_conf.equalization_trigger_days * 24 * 60 * 60;
 
     charger.time_state_changed = time(NULL) - 1;
     bat_terminal.current = bat_conf.topping_cutoff_current - 0.1;
-    bat_terminal.bus->voltage = bat_conf.topping_voltage -
-        bat_terminal.current * bat_terminal.bus->sink_droop_res + 0.1;
+    bat_terminal.bus->voltage =
+        bat_conf.topping_voltage - bat_terminal.current * bat_terminal.bus->sink_droop_res + 0.1;
     charger.charge_control(&bat_conf);
     TEST_ASSERT_EQUAL(CHG_STATE_EQUALIZATION, charger.state);
 }
-
 
 void float_to_equalization_if_enabled_and_deep_dis_limit_reached()
 {
@@ -200,20 +197,19 @@ void float_to_equalization_if_enabled_and_deep_dis_limit_reached()
 
     charger.time_state_changed = time(NULL) - 1;
     bat_terminal.current = bat_conf.topping_cutoff_current - 0.1;
-    bat_terminal.bus->voltage = bat_conf.topping_voltage -
-        bat_terminal.current * bat_terminal.bus->sink_droop_res + 0.1;
+    bat_terminal.bus->voltage =
+        bat_conf.topping_voltage - bat_terminal.current * bat_terminal.bus->sink_droop_res + 0.1;
     charger.charge_control(&bat_conf);
     TEST_ASSERT_EQUAL(CHG_STATE_EQUALIZATION, charger.state);
 }
-
 
 void stop_equalization_after_time_limit()
 {
     float_to_equalization_if_enabled_and_time_limit_reached();
 
     charger.time_state_changed = time(NULL) - bat_conf.equalization_duration + 1;
-    bat_terminal.bus->voltage = bat_conf.equalization_voltage -
-        bat_terminal.current * bat_terminal.bus->sink_droop_res + 0.1;
+    bat_terminal.bus->voltage = bat_conf.equalization_voltage
+                                - bat_terminal.current * bat_terminal.bus->sink_droop_res + 0.1;
 
     charger.charge_control(&bat_conf);
     TEST_ASSERT_EQUAL(CHG_STATE_EQUALIZATION, charger.state);
@@ -322,7 +318,7 @@ int bat_charger_tests()
     RUN_TEST(float_to_equalization_if_enabled_and_deep_dis_limit_reached);
     RUN_TEST(stop_equalization_after_time_limit);
 
-    //RUN_TEST(restart_bulk_from_float_if_voltage_drops);
+    // RUN_TEST(restart_bulk_from_float_if_voltage_drops);
 
     // TODO: temperature compensation
     // TODO: current compensation
@@ -332,11 +328,11 @@ int bat_charger_tests()
     RUN_TEST(stop_discharge_at_undertemp);
     RUN_TEST(restart_discharge_if_allowed);
 
-    //RUN_TEST(battery_values_propagated_to_lv_bus_int);
+    // RUN_TEST(battery_values_propagated_to_lv_bus_int);
 
     // ToDo: SOC calculation
-    //RUN_TEST(no_soc_above_100);
-    //RUN_TEST(no_soc_below_0);
+    // RUN_TEST(no_soc_above_100);
+    // RUN_TEST(no_soc_below_0);
 
     return UNITY_END();
 }

--- a/tests/src/tests_daq.cpp
+++ b/tests/src/tests_daq.cpp
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "tests.h"
 #include "daq.h"
 #include "daq_stub.h"
 #include "helper.h"
 #include "setup.h"
+#include "tests.h"
 
 #include <stdint.h>
 
@@ -70,14 +70,14 @@ void check_solar_terminal_readings()
 {
     TEST_ASSERT_EQUAL_FLOAT(adcval.solar_voltage, round(hv_terminal.bus->voltage * 10) / 10);
     TEST_ASSERT_EQUAL_FLOAT(adcval.dcdc_current / adcval.solar_voltage * adcval.battery_voltage,
-        -round(hv_terminal.current * 10) / 10);
+                            -round(hv_terminal.current * 10) / 10);
 }
 
 void check_bat_terminal_readings()
 {
     TEST_ASSERT_EQUAL_FLOAT(adcval.battery_voltage, round(lv_terminal.bus->voltage * 10) / 10);
     TEST_ASSERT_EQUAL_FLOAT(adcval.dcdc_current - adcval.load_current,
-        round(lv_terminal.current * 10) / 10);
+                            round(lv_terminal.current * 10) / 10);
 }
 
 void check_load_terminal_readings()
@@ -116,7 +116,7 @@ void adc_alert_lv_undervoltage_triggering()
     daq_update();
 
     charger.discharge_control(&bat_conf);
-    TEST_ASSERT_EQUAL(false, dev_stat.has_error(ERR_BAT_UNDERVOLTAGE));  // ToDo
+    TEST_ASSERT_EQUAL(false, dev_stat.has_error(ERR_BAT_UNDERVOLTAGE)); // ToDo
 }
 
 void adc_alert_lv_overvoltage_triggering()
@@ -136,7 +136,7 @@ void adc_alert_lv_overvoltage_triggering()
     TEST_ASSERT_EQUAL(false, dev_stat.has_error(ERR_BAT_OVERVOLTAGE));
     adc_update_value(ADC_POS(v_low));
     TEST_ASSERT_EQUAL(true, dev_stat.has_error(ERR_BAT_OVERVOLTAGE));
-    //TEST_ASSERT_EQUAL(false, pwm_switch.active());
+    // TEST_ASSERT_EQUAL(false, pwm_switch.active());
     TEST_ASSERT_EQUAL(DCDC_CONTROL_OFF, dcdc.state);
 
     // reset values
@@ -203,7 +203,7 @@ int daq_tests()
     RUN_TEST(check_bat_terminal_readings);
     RUN_TEST(check_load_terminal_readings);
 
-    //RUN_TEST(check_temperature_readings);     // TODO
+    // RUN_TEST(check_temperature_readings);     // TODO
 
     RUN_TEST(adc_alert_lv_undervoltage_triggering);
     RUN_TEST(adc_alert_lv_overvoltage_triggering);

--- a/tests/src/tests_dcdc.cpp
+++ b/tests/src/tests_dcdc.cpp
@@ -8,9 +8,9 @@
 
 #include "half_bridge.h"
 
-#include <time.h>
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
+#include <time.h>
 
 #include "setup.h"
 
@@ -49,7 +49,7 @@ static void start_buck()
     half_bridge_init(70, 200, 12 / dcdc.hs_voltage_max, 0.97);
     dcdc.control();
     dcdc.control();
-    dcdc.control();    // call multiple times because of startup delay
+    dcdc.control(); // call multiple times because of startup delay
     TEST_ASSERT_EQUAL(DCDC_CONTROL_MPPT, dcdc.state);
 }
 
@@ -89,7 +89,7 @@ static void start_boost()
     half_bridge_init(70, 200, 12 / dcdc.hs_voltage_max, 0.97);
     dcdc.control();
     dcdc.control();
-    dcdc.control();        // call multiple times because of startup delay
+    dcdc.control(); // call multiple times because of startup delay
     TEST_ASSERT_EQUAL(DCDC_CONTROL_MPPT, dcdc.state);
 }
 
@@ -218,7 +218,7 @@ void buck_derating_output_voltage_too_high()
     lv_terminal.bus->voltage = lv_terminal.bus->sink_voltage_intercept + 0.1;
     dcdc.control();
     float pwm_after = half_bridge_get_duty_cycle();
-    TEST_ASSERT(pwm_after < pwm_before);    // less duty cycle = higher voltage
+    TEST_ASSERT(pwm_after < pwm_before); // less duty cycle = higher voltage
     TEST_ASSERT_EQUAL(DCDC_CONTROL_CV_LS, dcdc.state);
 }
 
@@ -307,7 +307,7 @@ void buck_correct_mppt_operation()
     float pwm2 = half_bridge_get_duty_cycle();
     TEST_ASSERT(pwm2 > pwm1);
 
-    dcdc.power = 6;     // decrease power to make the direction turn around
+    dcdc.power = 6; // decrease power to make the direction turn around
     dcdc.control();
     float pwm3 = half_bridge_get_duty_cycle();
     TEST_ASSERT(pwm3 < pwm2);
@@ -332,7 +332,7 @@ void boost_derating_output_voltage_too_high()
     hv_terminal.bus->voltage = hv_terminal.bus->sink_voltage_intercept + 0.5;
     dcdc.control();
     float pwm_after = half_bridge_get_duty_cycle();
-    TEST_ASSERT(pwm_after > pwm_before);    // higher duty cycle = less power
+    TEST_ASSERT(pwm_after > pwm_before); // higher duty cycle = less power
 }
 
 void boost_derating_output_current_too_high()
@@ -407,7 +407,7 @@ void boost_correct_mppt_operation()
     float pwm2 = half_bridge_get_duty_cycle();
     TEST_ASSERT(pwm2 < pwm1);
 
-    dcdc.power = -6;     // decrease power to make the direction turn around
+    dcdc.power = -6; // decrease power to make the direction turn around
     dcdc.control();
     float pwm3 = half_bridge_get_duty_cycle();
     TEST_ASSERT(pwm3 > pwm2);

--- a/tests/src/tests_device_status.cpp
+++ b/tests/src/tests_device_status.cpp
@@ -6,9 +6,9 @@
 
 #include "tests.h"
 
-#include <time.h>
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
+#include <time.h>
 
 #include "setup.h"
 
@@ -23,7 +23,7 @@ void reset_counters_at_start_of_day()
     bat_terminal.pos_energy_Wh = 4.0;
     load.pos_energy_Wh = 9.0;
 
-    // 5 houurs without sun
+    // 5 hours without sun
     for (int i = 0; i <= 5 * 60 * 60; i++) {
         dev_stat.update_energy();
     }

--- a/tests/src/tests_half_bridge.cpp
+++ b/tests/src/tests_half_bridge.cpp
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "tests.h"
 #include "half_bridge.h"
+#include "tests.h"
 
-#include <time.h>
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
+#include <time.h>
 
-#define MAX_PWM_DUTY 0.97
-#define MIN_PWM_DUTY 0.1
-#define MID_PWM_DUTY ((MIN_PWM_DUTY + MAX_PWM_DUTY)/2)
-#define PWM_F_KHZ 70
+#define MAX_PWM_DUTY    0.97
+#define MIN_PWM_DUTY    0.1
+#define MID_PWM_DUTY    ((MIN_PWM_DUTY + MAX_PWM_DUTY) / 2)
+#define PWM_F_KHZ       70
 #define PWM_DEADTIME_NS 300
 
 const float duty_epsilon = 0.006;

--- a/tests/src/tests_load.cpp
+++ b/tests/src/tests_load.cpp
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "tests.h"
-#include "daq_stub.h"
 #include "daq.h"
+#include "daq_stub.h"
+#include "tests.h"
 
-#include <time.h>
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
+#include <time.h>
 
 #include "setup.h"
 
@@ -103,7 +103,7 @@ void control_on_to_off_overvoltage()
     TEST_ASSERT_EQUAL(0, load_out.error_flags);
     TEST_ASSERT_EQUAL(LOAD_STATE_ON, load_out.state);
 
-    load_out.control();     // once more
+    load_out.control(); // once more
     TEST_ASSERT_EQUAL(ERR_LOAD_OVERVOLTAGE, load_out.error_flags);
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF, load_out.state);
 }
@@ -124,7 +124,7 @@ void control_on_to_off_overvoltage_dual_battery()
     TEST_ASSERT_EQUAL(0, load_out.error_flags);
     TEST_ASSERT_EQUAL(LOAD_STATE_ON, load_out.state);
 
-    load_out.control();     // once more
+    load_out.control(); // once more
     TEST_ASSERT_EQUAL(ERR_LOAD_OVERVOLTAGE, load_out.error_flags);
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF, load_out.state);
 }
@@ -140,7 +140,8 @@ void control_on_to_off_overcurrent()
     load_out.control();
     TEST_ASSERT_EQUAL(LOAD_STATE_ON, load_out.state);
 
-    // almost 2x current = 4x heat generation: Should definitely trigger after waiting one time constant
+    // almost 2x current = 4x heat generation: Should definitely trigger after waiting one time
+    // constant
     int trigger_steps = DT_PROP(DT_PATH(pcb), mosfets_tau_ja) * CONFIG_CONTROL_FREQUENCY;
     for (int i = 0; i <= trigger_steps; i++) {
         load_out.control();
@@ -233,7 +234,7 @@ void control_off_overvoltage_to_on_at_lower_voltage()
     TEST_ASSERT_EQUAL(ERR_LOAD_OVERVOLTAGE, load_out.error_flags);
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF, load_out.state);
 
-    bus.voltage = load_out.overvoltage - 0.1;     // test hysteresis
+    bus.voltage = load_out.overvoltage - 0.1; // test hysteresis
     load_out.control();
     TEST_ASSERT_EQUAL(ERR_LOAD_OVERVOLTAGE, load_out.error_flags);
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF, load_out.state);
@@ -256,7 +257,7 @@ void control_off_overvoltage_to_on_at_lower_voltage_dual_battery()
     TEST_ASSERT_EQUAL(ERR_LOAD_OVERVOLTAGE, load_out.error_flags);
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF, load_out.state);
 
-    bus.voltage = (load_out.overvoltage - 0.1) * bus.series_multiplier;     // test hysteresis
+    bus.voltage = (load_out.overvoltage - 0.1) * bus.series_multiplier; // test hysteresis
     load_out.control();
     TEST_ASSERT_EQUAL(ERR_LOAD_OVERVOLTAGE, load_out.error_flags);
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF, load_out.state);
@@ -278,7 +279,7 @@ void control_off_short_circuit_flag_reset()
     TEST_ASSERT_EQUAL(ERR_LOAD_SHORT_CIRCUIT, load_out.error_flags);
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF, load_out.state);
 
-    load_out.enable = false;        // this is like a manual reset
+    load_out.enable = false; // this is like a manual reset
     load_out.control();
     TEST_ASSERT_EQUAL(0, load_out.error_flags);
     TEST_ASSERT_EQUAL(LOAD_STATE_OFF, load_out.state);

--- a/tests/src/tests_power_port.cpp
+++ b/tests/src/tests_power_port.cpp
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "tests.h"
-#include "daq_stub.h"
 #include "daq.h"
+#include "daq_stub.h"
+#include "tests.h"
 
-#include <time.h>
-#include <stdio.h>
 #include <math.h>
+#include <stdio.h>
+#include <time.h>
 
 #include "setup.h"
 
@@ -46,7 +46,7 @@ void energy_calculation_init()
     prepare_adc_filtered();
     daq_update();
 
-    for (int i = 0; i < 60*60*sun_hours; i++) {
+    for (int i = 0; i < 60 * 60 * sun_hours; i++) {
         hv_terminal.energy_balance();
         lv_terminal.energy_balance();
         load.energy_balance();
@@ -58,7 +58,7 @@ void energy_calculation_init()
     prepare_adc_filtered();
     daq_update();
 
-    for (int i = 0; i < 60*60*night_hours; i++) {
+    for (int i = 0; i < 60 * 60 * night_hours; i++) {
         hv_terminal.energy_balance();
         lv_terminal.energy_balance();
         load.energy_balance();
@@ -69,26 +69,32 @@ void charging_energy_calculation_valid()
 {
     energy_calculation_init();
     // charging only during sun hours
-    TEST_ASSERT_EQUAL_FLOAT(round(sun_hours * lv_terminal.bus->voltage * (dcdc_current_sun - load_current)), round(lv_terminal.pos_energy_Wh));
+    TEST_ASSERT_EQUAL_FLOAT(
+        round(sun_hours * lv_terminal.bus->voltage * (dcdc_current_sun - load_current)),
+        round(lv_terminal.pos_energy_Wh));
 }
 
 void discharging_energy_calculation_valid()
 {
     energy_calculation_init();
     // discharging (sum of current) only during dis hours
-    TEST_ASSERT_EQUAL_FLOAT(round(night_hours * lv_terminal.bus->voltage * adcval.load_current), round(lv_terminal.neg_energy_Wh));
+    TEST_ASSERT_EQUAL_FLOAT(round(night_hours * lv_terminal.bus->voltage * adcval.load_current),
+                            round(lv_terminal.neg_energy_Wh));
 }
 
 void solar_input_energy_calculation_valid()
 {
     energy_calculation_init();
-    TEST_ASSERT_EQUAL_FLOAT(round(sun_hours * lv_terminal.bus->voltage * dcdc_current_sun), round(hv_terminal.neg_energy_Wh));
+    TEST_ASSERT_EQUAL_FLOAT(round(sun_hours * lv_terminal.bus->voltage * dcdc_current_sun),
+                            round(hv_terminal.neg_energy_Wh));
 }
 
 void load_output_energy_calculation_valid()
 {
     energy_calculation_init();
-    TEST_ASSERT_EQUAL_FLOAT(round((sun_hours + night_hours) * lv_terminal.bus->voltage * adcval.load_current), round(load.pos_energy_Wh));
+    TEST_ASSERT_EQUAL_FLOAT(
+        round((sun_hours + night_hours) * lv_terminal.bus->voltage * adcval.load_current),
+        round(load.pos_energy_Wh));
 }
 
 int power_port_tests()


### PR DESCRIPTION
This PR applies the suggestions by @hogthrob in PR #127.

The format definition tries to maintain the previously used [Libre Solar firmware coding style](https://github.com/LibreSolar/coding-style) as much as possible.

Setting `BraceWrapping: AfterEnum: false` did not have any effect, so I'm going to change the coding style such that `enum`s and `struct`s have the opening brace in the next line just like classes.

Also I couldn't manage to keep empty `while` loops (e.g. to wait for a register to be set) in a single line, so I'm just accepting that the formatter put the closing bracket in the next line.